### PR TITLE
fix auto-translation miss in 'zh_CN', 'zh_TW' and 'ja'

### DIFF
--- a/src/_locales/ja/messages.json
+++ b/src/_locales/ja/messages.json
@@ -10,7 +10,7 @@
     "message": "日曜日"
   },
   "monday": {
-    "message": "月曜"
+    "message": "月曜日"
   },
   "tuesday": {
     "message": "火曜日"

--- a/src/_locales/zh_CN/messages.json
+++ b/src/_locales/zh_CN/messages.json
@@ -35,13 +35,13 @@
     "message": "二月"
   },
   "march": {
-    "message": "游行"
+    "message": "三月"
   },
   "april": {
     "message": "四月"
   },
   "may": {
-    "message": "可能"
+    "message": "五月"
   },
   "june": {
     "message": "六月"
@@ -110,19 +110,19 @@
     "message": "如果您认为 CaretTab 对您是有用的, 请考虑给一点小费来赞助它。小费会帮助它保持没有广告和免费！开发者衷心感谢您的支持！"
   },
   "generousTip": {
-    "message": "慷慨的<br>小费"
+    "message": "少量的<br>小费"
   },
   "largeTip": {
-    "message": "大量的<br>小费"
+    "message": "普通的<br>小费"
   },
   "massiveTip": {
-    "message": "少量的<br>小费"
+    "message": "大量的<br>小费"
   },
   "anythingHelps": {
     "message": "任何形式的<br>帮助！"
   },
   "otherTip": {
-    "message": "其他"
+    "message": "其它金额"
   },
   "viaPaypal": {
     "message": "小费通过<br>PayPal支付<br><b>谢谢！</b>"

--- a/src/_locales/zh_TW/messages.json
+++ b/src/_locales/zh_TW/messages.json
@@ -35,13 +35,13 @@
     "message": "二月"
   },
   "march": {
-    "message": "遊行"
+    "message": "三月"
   },
   "april": {
     "message": "四月"
   },
   "may": {
-    "message": "可能"
+    "message": "五月"
   },
   "june": {
     "message": "六月"
@@ -110,19 +110,19 @@
     "message": "如果您認為 CaretTab 對您是有用的, 請考慮給一點小費來贊助它。小費會幫助它保持沒有廣告和免費！開發者衷心感謝您的支援！"
   },
   "generousTip": {
-    "message": "慷慨的<br>小費"
+    "message": "少量的<br>小費"
   },
   "largeTip": {
-    "message": "大量的<br>小費"
+    "message": "普通的<br>小費"
   },
   "massiveTip": {
-    "message": "少量的<br>小費"
+    "message": "大量的<br>小費"
   },
   "anythingHelps": {
     "message": "任何形式的<br>幫助！"
   },
   "otherTip": {
-    "message": "其他"
+    "message": "其他金額"
   },
   "viaPaypal": {
     "message": "小費通過<br>PayPal支付<br><b>謝謝！</b>"


### PR DESCRIPTION
fix auto-translation miss in 'zh_CN', 'zh_TW' and 'ja' and some of my personal miss in 'zh_CN' and 'zh_TW'