### PR TITLE
Configure and fix linting to give good warnings

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,6 +14,9 @@
       "error",
       "windows"
     ],
+    "no-console": [
+      "off"
+    ],
     "quotes": [
       "error",
       "double"

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,6 +1,8 @@
 {
   "env": {
-    "browser": true
+    "browser": true,
+    "jquery": true,
+    "webextensions": true
   },
   "extends": "eslint:recommended",
   "rules": {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,6 +5,9 @@
     "webextensions": true
   },
   "extends": "eslint:recommended",
+  "globals": {
+    "moment": false
+  },
   "rules": {
     "indent": [
       "error",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "src/app.js",
   "scripts": {
     "scss": "node-sass --output-style compressed -o dist/css src/scss --source-map true --source-map-embed true",
-    "lint": "eslint src/js",
+    "lint": "eslint src/js/*.js",
     "uglify": "mkdirp dist/js && uglifyjs src/js/app.js src/js/links.js src/js/install_status.js src/js/load.js src/js/set_default.js src/js/actions.js src/js/functions.js src/js/run.js -c -m --output dist/js/app.min.js --source-map url=inline",
     "copy": "cp src/carettab.htm dist/ && cp -R src/assets/ dist/assets/ && cp -R src/js/vendor dist/js/vendor && cp -R src/_locales dist/_locales && cp src/js/update.js dist/js/update.js",
     "copy:chrome": "npm run copy && cp src/manifest.json dist/manifest.json",

--- a/src/js/actions.js
+++ b/src/js/actions.js
@@ -1,702 +1,702 @@
 // ##############################################
 // Actions 
 // ##############################################
-$('#set-clock1').click(function() {
-  if ($('#set-clock1').is(':checked')) {
-    sPrimaryClock = 'on';
+$("#set-clock1").click(function() {
+  if ($("#set-clock1").is(":checked")) {
+    sPrimaryClock = "on";
   } else {
-    sPrimaryClock = 'off';
+    sPrimaryClock = "off";
   }
   tPrimaryClock();
   updateAll();
 });
-$('#set-seconds').click(function() {
-  if ($('#set-seconds').is(':checked')) {
-    sSeconds = 'on';
+$("#set-seconds").click(function() {
+  if ($("#set-seconds").is(":checked")) {
+    sSeconds = "on";
   } else {
-    sSeconds = 'off';
+    sSeconds = "off";
   }
   tSeconds();
   updateAll();
 });
-$('#set-dimseconds').click(function() {
-  if ($('#set-dimseconds').is(':checked')) {
-    sDimSeconds = 'on';
+$("#set-dimseconds").click(function() {
+  if ($("#set-dimseconds").is(":checked")) {
+    sDimSeconds = "on";
   } else {
-    sDimSeconds = 'off';
+    sDimSeconds = "off";
   }
   tDimSeconds();
 });
-$('#set-meridiem').click(function() {
-  if ($('#set-meridiem').is(':checked')) {
-    sMeridiem = 'on';
+$("#set-meridiem").click(function() {
+  if ($("#set-meridiem").is(":checked")) {
+    sMeridiem = "on";
   } else {
-    sMeridiem = 'off';
+    sMeridiem = "off";
   }
   tMeridiem();
   updateAll();
 });
-$('#set-military').click(function() {
-  if ($('#set-military').is(':checked')) {
-    sMilitary = 'on';
+$("#set-military").click(function() {
+  if ($("#set-military").is(":checked")) {
+    sMilitary = "on";
   } else {
-    sMilitary = 'off';
+    sMilitary = "off";
   }
   tMilitary();
   updateAll();
 });
-$('#set-delimiter').click(function() {
-  if ($('#set-delimiter').is(':checked')) {
-    sDelimiter = 'on';
+$("#set-delimiter").click(function() {
+  if ($("#set-delimiter").is(":checked")) {
+    sDelimiter = "on";
   } else {
-    sDelimiter = 'off';
+    sDelimiter = "off";
   }
   tDelimiter();
   updateAll();
 });
-$('#set-blinking').click(function() {
-  if ($('#set-blinking').is(':checked')) {
-    sBlinking = 'on';
+$("#set-blinking").click(function() {
+  if ($("#set-blinking").is(":checked")) {
+    sBlinking = "on";
   } else {
-    sBlinking = 'off';
+    sBlinking = "off";
   }
   tBlinking();
   updateAll();
 });
-$('#set-time1-zone').change(function() {
+$("#set-time1-zone").change(function() {
   sPrimaryClockTimezone = $(this).val();
   tPrimaryClockTimezone(sPrimaryClockTimezone);
 });
-$('#set-time2').click(function() {
-  if ($('#set-time2').is(':checked')) {
-    s2ndClock = 'on';
+$("#set-time2").click(function() {
+  if ($("#set-time2").is(":checked")) {
+    s2ndClock = "on";
   } else {
-    s2ndClock = 'off';
+    s2ndClock = "off";
   }
   t2ndClock();
   updateAll();
 });
-$('#set-time2-zone').change(function() {
+$("#set-time2-zone").change(function() {
   s2ndClockTimezone = $(this).val();
   t2ndClockTimezone(s2ndClockTimezone);
   updateAll();
 });
-$('#set-time2-label').on("blur", function() {
+$("#set-time2-label").on("blur", function() {
   s2ndClockLabel = $(this).val();
   t2ndClockLabel(s2ndClockLabel);
 });
-$('#set-time3').click(function() {
-  if ($('#set-time3').is(':checked')) {
-    s3rdClock = 'on';
+$("#set-time3").click(function() {
+  if ($("#set-time3").is(":checked")) {
+    s3rdClock = "on";
   } else {
-    s3rdClock = 'off';
+    s3rdClock = "off";
   }
   t3rdClock();
   updateAll();
 });
-$('#set-time3-zone').change(function() {
+$("#set-time3-zone").change(function() {
   s3rdClockTimezone = $(this).val();
   t3rdClockTimezone(s3rdClockTimezone);
   updateAll();
 });
-$('#set-time3-label').on("blur", function() {
+$("#set-time3-label").on("blur", function() {
   s3rdClockLabel = $(this).val();
   t3rdClockLabel(s3rdClockLabel);
 });
-$('#set-time4').click(function() {
-  if ($('#set-time4').is(':checked')) {
-    s4thClock = 'on';
+$("#set-time4").click(function() {
+  if ($("#set-time4").is(":checked")) {
+    s4thClock = "on";
   } else {
-    s4thClock = 'off';
+    s4thClock = "off";
   }
   t4thClock();
   updateAll();
 });
-$('#set-time4-zone').change(function() {
+$("#set-time4-zone").change(function() {
   s4thClockTimezone = $(this).val();
   t4thClockTimezone(s4thClockTimezone);
   updateAll();
 });
-$('#set-time4-label').on("blur", function() {
+$("#set-time4-label").on("blur", function() {
   s4thClockLabel = $(this).val();
   t4thClockLabel(s4thClockLabel);
 });
-$('#set-date').click(function() {
-  if ($('#set-date').is(':checked')) {
-    sDate = 'on';
+$("#set-date").click(function() {
+  if ($("#set-date").is(":checked")) {
+    sDate = "on";
   } else {
-    sDate = 'off';
+    sDate = "off";
   }
   tDate();
   updateAll();
 });
-$('#set-day').click(function() {
-  if ($('#set-day').is(':checked')) {
-    sDay = 'on';
+$("#set-day").click(function() {
+  if ($("#set-day").is(":checked")) {
+    sDay = "on";
   } else {
-    sDay = 'off';
+    sDay = "off";
   }
   tDay();
   updateAll();
 });
-$('#set-year').click(function() {
-  if ($('#set-year').is(':checked')) {
-    sYear = 'on';
+$("#set-year").click(function() {
+  if ($("#set-year").is(":checked")) {
+    sYear = "on";
   } else {
-    sYear = 'off';
+    sYear = "off";
   }
   tYear();
   updateAll();
 });
-$('#set-shortdate').click(function() {
-  if ($('#set-shortdate').is(':checked')) {
-    sShortDate = 'on';
+$("#set-shortdate").click(function() {
+  if ($("#set-shortdate").is(":checked")) {
+    sShortDate = "on";
   } else {
-    sShortDate = 'off';
+    sShortDate = "off";
   }
   tShortDate();
   updateAll();
 });
-$('#set-dateformat').on("input change", function() {
+$("#set-dateformat").on("input change", function() {
   sDateFormat = $(this).val();
   tDateFormat(sDateFormat);
   updateAll();
 });
-$('input[name="set-date-delimiter"]').click(function() {
+$("input[name=\"set-date-delimiter\"]").click(function() {
   sDateDelimiter = $(this).val();
   tDateDelimiter();
   updateAll();
 });
-$('#set-week').click(function() {
-  if ($('#set-week').is(':checked')) {
-    sWeek = 'on';
+$("#set-week").click(function() {
+  if ($("#set-week").is(":checked")) {
+    sWeek = "on";
   } else {
-    sWeek = 'off';
+    sWeek = "off";
   }
   tWeek();
   updateAll();
 });
-$('input[name="set-week-label"]').click(function() {
+$("input[name=\"set-week-label\"]").click(function() {
   sWeekLabel = $(this).val();
   tWeekLabel();
   updateAll();
 });
-$('#set-background').change(function() {
+$("#set-background").change(function() {
   sBackground = $(this).val();
   tBackground(sBackground);
 });
-$('#set-background-value').on("blur", function() {
+$("#set-background-value").on("blur", function() {
   sBackground = $(this).val();
   tBackground(sBackground);
 });
-$('#set-foreground').change(function() {
+$("#set-foreground").change(function() {
   sForeground = $(this).val();
   tForeground(sForeground);
 });
-$('#set-foreground-value').on("blur", function() {
+$("#set-foreground-value").on("blur", function() {
   sForeground = $(this).val();
   tForeground(sForeground);
 });
-$('#set-tab-title').on("input change", function() {
+$("#set-tab-title").on("input change", function() {
   sTabTitle = $(this).val();
   tTabTitle(sTabTitle);
   updateAll();
 });
-$('#set-tab-custom-message').on("blur", function() {
+$("#set-tab-custom-message").on("blur", function() {
   sTabTitleCustomMessage = $(this).val();
   tTabTitleCustomMessage(sTabTitleCustomMessage);
   updateAll();
 });
-$('#set-message').click(function() {
-  if ($('#set-message').is(':checked')) {
-    sCustomMessage = 'on';
+$("#set-message").click(function() {
+  if ($("#set-message").is(":checked")) {
+    sCustomMessage = "on";
     tCustomMessage();
   } else {
-    sCustomMessage = 'off';
+    sCustomMessage = "off";
     tCustomMessage();
   }
 });
-$('#set-message-text').on("blur", function() {
+$("#set-message-text").on("blur", function() {
   sCustomMessageText = $(this).val();
   tCustomMessageText(sCustomMessageText);
 });
-$('#set-search').click(function() {
-  if ($('#set-search').is(':checked')) {
-    sSearch = 'on';
+$("#set-search").click(function() {
+  if ($("#set-search").is(":checked")) {
+    sSearch = "on";
   } else {
-    sSearch = 'off';
+    sSearch = "off";
   }
   tSearch();
 });
-$('#set-engine').on("input change", function() {
+$("#set-engine").on("input change", function() {
   sEngine = $(this).val();
   tEngine(sEngine);
 });
-$('#set-animation').click(function() {
-  if ($('#set-animation').is(':checked')) {
-    sAnimation = 'on';
+$("#set-animation").click(function() {
+  if ($("#set-animation").is(":checked")) {
+    sAnimation = "on";
   } else {
-    sAnimation = 'off';
+    sAnimation = "off";
   }
   tAnimation();
 });
-$('#set-brackets').click(function() {
-  if ($('#set-brackets').is(':checked')) {
-    sBrackets = 'on';
+$("#set-brackets").click(function() {
+  if ($("#set-brackets").is(":checked")) {
+    sBrackets = "on";
   } else {
-    sBrackets = 'off';
+    sBrackets = "off";
   }
   tBrackets();
 });
-$('#set-dimbrackets').click(function() {
-  if ($('#set-dimbrackets').is(':checked')) {
-    sDimBrackets = 'on';
+$("#set-dimbrackets").click(function() {
+  if ($("#set-dimbrackets").is(":checked")) {
+    sDimBrackets = "on";
   } else {
-    sDimBrackets = 'off';
+    sDimBrackets = "off";
   }
   tDimBrackets();
 });
-$('#set-dimdelimiter').click(function() {
-  if ($('#set-dimdelimiter').is(':checked')) {
-    sDimDelimiter = 'on';
+$("#set-dimdelimiter").click(function() {
+  if ($("#set-dimdelimiter").is(":checked")) {
+    sDimDelimiter = "on";
   } else {
-    sDimDelimiter = 'off';
+    sDimDelimiter = "off";
   }
   tDimDelimiter();
 });
-$('input[name="set-scale"]').on("input change", function() {
+$("input[name=\"set-scale\"]").on("input change", function() {
   sScale = $(this).val();
   tScale();
 });
-$('input[name="set-bracket-style"]').click(function() {
+$("input[name=\"set-bracket-style\"]").click(function() {
   sBracketStyle = $(this).val();
   tBracketStyle();
 });
-$('input[name="set-font"]').click(function() {
+$("input[name=\"set-font\"]").click(function() {
   sFont = $(this).val();
   tFont();
 });
-$('#set-hide-settings-toggle').click(function() {
-  if ($('#set-hide-settings-toggle').is(':checked')) {
-    sHideSettingsToggle = 'on';
+$("#set-hide-settings-toggle").click(function() {
+  if ($("#set-hide-settings-toggle").is(":checked")) {
+    sHideSettingsToggle = "on";
   } else {
-    sHideSettingsToggle = 'off';
+    sHideSettingsToggle = "off";
   }
   tHideSettingsToggle();
 });
-$('#set-analog').click(function() {
-  if ($('#set-analog').is(':checked')) {
-    sAnalog = 'off';
+$("#set-analog").click(function() {
+  if ($("#set-analog").is(":checked")) {
+    sAnalog = "off";
   } else {
-    sAnalog = 'on';
+    sAnalog = "on";
   }
   tAnalog();
   updateAll();
 });
 
 // CLick theme
-$('#theme01').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme01").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme02').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#7AC943';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme02").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#7AC943";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme03').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#00A99D';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme03").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#00A99D";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme04').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#3FA9F5';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme04").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#3FA9F5";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme05').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#93278F';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme05").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#93278F";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme06').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#FF7BAC';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme06").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#FF7BAC";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme07').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#FF1D25';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme07").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#FF1D25";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme08').click(function() {
-  sBackground = '#FFFFFF';
-  sForeground = '#FF931E';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme08").click(function() {
+  sBackground = "#FFFFFF";
+  sForeground = "#FF931E";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme09').click(function() {
-  sBackground = '#000000';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme09").click(function() {
+  sBackground = "#000000";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme10').click(function() {
-  sBackground = '#000000';
-  sForeground = '#7AC943';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme10").click(function() {
+  sBackground = "#000000";
+  sForeground = "#7AC943";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme11').click(function() {
-  sBackground = '#000000';
-  sForeground = '#00A99D';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme11").click(function() {
+  sBackground = "#000000";
+  sForeground = "#00A99D";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme12').click(function() {
-  sBackground = '#000000';
-  sForeground = '#3FA9F5';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme12").click(function() {
+  sBackground = "#000000";
+  sForeground = "#3FA9F5";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme13').click(function() {
-  sBackground = '#000000';
-  sForeground = '#93278F';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme13").click(function() {
+  sBackground = "#000000";
+  sForeground = "#93278F";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme14').click(function() {
-  sBackground = '#000000';
-  sForeground = '#FF7BAC';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme14").click(function() {
+  sBackground = "#000000";
+  sForeground = "#FF7BAC";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme15').click(function() {
-  sBackground = '#000000';
-  sForeground = '#FF1D25';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme15").click(function() {
+  sBackground = "#000000";
+  sForeground = "#FF1D25";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme16').click(function() {
-  sBackground = '#000000';
-  sForeground = '#FF931E';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme16").click(function() {
+  sBackground = "#000000";
+  sForeground = "#FF931E";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme17').click(function() {
-  sBackground = '#E6E6E6';
-  sForeground = '#333333';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme17").click(function() {
+  sBackground = "#E6E6E6";
+  sForeground = "#333333";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme18').click(function() {
-  sBackground = '#7AC943';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme18").click(function() {
+  sBackground = "#7AC943";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme19').click(function() {
-  sBackground = '#00A99D';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme19").click(function() {
+  sBackground = "#00A99D";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme20').click(function() {
-  sBackground = '#3FA9F5';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme20").click(function() {
+  sBackground = "#3FA9F5";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme21').click(function() {
-  sBackground = '#93278F';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme21").click(function() {
+  sBackground = "#93278F";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme22').click(function() {
-  sBackground = '#FF7BAC';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme22").click(function() {
+  sBackground = "#FF7BAC";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme23').click(function() {
-  sBackground = '#FF1D25';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme23").click(function() {
+  sBackground = "#FF1D25";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme24').click(function() {
-  sBackground = '#FF931E';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme24").click(function() {
+  sBackground = "#FF931E";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme25').click(function() {
-  sBackground = '#333333';
-  sForeground = '#E6E6E6';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme25").click(function() {
+  sBackground = "#333333";
+  sForeground = "#E6E6E6";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme26').click(function() {
-  sBackground = '#7AC943';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme26").click(function() {
+  sBackground = "#7AC943";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme27').click(function() {
-  sBackground = '#00A99D';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme27").click(function() {
+  sBackground = "#00A99D";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme28').click(function() {
-  sBackground = '#3FA9F5';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme28").click(function() {
+  sBackground = "#3FA9F5";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme29').click(function() {
-  sBackground = '#93278F';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme29").click(function() {
+  sBackground = "#93278F";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme30').click(function() {
-  sBackground = '#FF7BAC';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme30").click(function() {
+  sBackground = "#FF7BAC";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme31').click(function() {
-  sBackground = '#FF1D25';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme31").click(function() {
+  sBackground = "#FF1D25";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme32').click(function() {
-  sBackground = '#FF931E';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme32").click(function() {
+  sBackground = "#FF931E";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme33').click(function() {
-  sBackground = '#BDCCD4';
-  sForeground = '#534741';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme33").click(function() {
+  sBackground = "#BDCCD4";
+  sForeground = "#534741";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme34').click(function() {
-  sBackground = '#E2EDC1';
-  sForeground = '#00A055';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme34").click(function() {
+  sBackground = "#E2EDC1";
+  sForeground = "#00A055";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme35').click(function() {
-  sBackground = '#C9F2EE';
-  sForeground = '#0000FF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme35").click(function() {
+  sBackground = "#C9F2EE";
+  sForeground = "#0000FF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme36').click(function() {
-  sBackground = '#C8EAF5';
-  sForeground = '#00AEEF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme36").click(function() {
+  sBackground = "#C8EAF5";
+  sForeground = "#00AEEF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme37').click(function() {
-  sBackground = '#D8D6EC';
-  sForeground = '#702C8D';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme37").click(function() {
+  sBackground = "#D8D6EC";
+  sForeground = "#702C8D";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme38').click(function() {
-  sBackground = '#FCE3EE';
-  sForeground = '#F190AC';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme38").click(function() {
+  sBackground = "#FCE3EE";
+  sForeground = "#F190AC";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme39').click(function() {
-  sBackground = '#EEDFAC';
-  sForeground = '#534741';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme39").click(function() {
+  sBackground = "#EEDFAC";
+  sForeground = "#534741";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme40').click(function() {
-  sBackground = '#FFFAC0';
-  sForeground = '#F4783B';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme40").click(function() {
+  sBackground = "#FFFAC0";
+  sForeground = "#F4783B";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme41').click(function() {
-  sBackground = '#E1E9F2';
-  sForeground = '#004080';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme41").click(function() {
+  sBackground = "#E1E9F2";
+  sForeground = "#004080";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme42').click(function() {
-  sBackground = '#EAF3E0';
-  sForeground = '#008080';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme42").click(function() {
+  sBackground = "#EAF3E0";
+  sForeground = "#008080";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme43').click(function() {
-  sBackground = '#004040';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme43").click(function() {
+  sBackground = "#004040";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme44').click(function() {
-  sBackground = '#0000FF';
-  sForeground = '#FFFFFF';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme44").click(function() {
+  sBackground = "#0000FF";
+  sForeground = "#FFFFFF";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme45').click(function() {
-  sBackground = '#93278F';
-  sForeground = '#FF931E';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme45").click(function() {
+  sBackground = "#93278F";
+  sForeground = "#FF931E";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme46').click(function() {
-  sBackground = '#FAC8D3';
-  sForeground = '#895881';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme46").click(function() {
+  sBackground = "#FAC8D3";
+  sForeground = "#895881";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme47').click(function() {
-  sBackground = '#C1172C';
-  sForeground = '#FFF200';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme47").click(function() {
+  sBackground = "#C1172C";
+  sForeground = "#FFF200";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
-$('#theme48').click(function() {
-  sBackground = '#FF8040';
-  sForeground = '#000000';
-  $('set-background').val(sBackground);
-  $('set-foreground').val(sForeground);
+$("#theme48").click(function() {
+  sBackground = "#FF8040";
+  sForeground = "#000000";
+  $("set-background").val(sBackground);
+  $("set-foreground").val(sForeground);
   tBackground(sBackground);
   tForeground(sForeground);
 });
 
 // Change tabs in Settings panel
-$('nav li button').click(function() {
-  var tab_id = $(this).attr('data-tab');
-  $('nav li button').removeClass('active');
-  $('.section').removeClass('active');
-  $(this).addClass('active');
-  $("#" + tab_id).addClass('active');
+$("nav li button").click(function() {
+  var tab_id = $(this).attr("data-tab");
+  $("nav li button").removeClass("active");
+  $(".section").removeClass("active");
+  $(this).addClass("active");
+  $("#" + tab_id).addClass("active");
 });
 
 // Open settings panel
-$('#settings-toggle').click(function() {
-  $('#settings-toggle').blur();
-  $('#config').toggleClass("active");
-  $('#carettab').toggleClass("active");
-  $('.carettab-status').fadeOut();
+$("#settings-toggle").click(function() {
+  $("#settings-toggle").blur();
+  $("#config").toggleClass("active");
+  $("#carettab").toggleClass("active");
+  $(".carettab-status").fadeOut();
   chrome.storage.sync.set({
-    'caretTabStatus': "existing"
+    "caretTabStatus": "existing"
   }, function() {
     if (!chrome.runtime.lastError) {
       console.log("^CaretTab - Set Status: existing");
@@ -705,10 +705,10 @@ $('#settings-toggle').click(function() {
 });
 
 // Close status message
-$('.status-message-close').click(function() {
-  $('.carettab-status').fadeOut();
+$(".status-message-close").click(function() {
+  $(".carettab-status").fadeOut();
   chrome.storage.sync.set({
-    'caretTabStatus': "existing"
+    "caretTabStatus": "existing"
   }, function() {
     if (!chrome.runtime.lastError) {
       console.log("^CaretTab - Set Status: existing");
@@ -717,16 +717,16 @@ $('.status-message-close').click(function() {
 });
 
 // Close settings panel via close button
-$('#close-settings').click(function() {
-  $('#config').toggleClass("active");
-  $('#carettab').toggleClass("active");
+$("#close-settings").click(function() {
+  $("#config").toggleClass("active");
+  $("#carettab").toggleClass("active");
 });
 
 // Close status message via close button
-$('.status-x').click(function() {
-  $('.carettab-status').fadeOut();
+$(".status-x").click(function() {
+  $(".carettab-status").fadeOut();
   chrome.storage.sync.set({
-    'caretTabStatus': "existing"
+    "caretTabStatus": "existing"
   }, function() {
     if (!chrome.runtime.lastError) {
       console.log("^CaretTab - Set Status: existing");
@@ -740,14 +740,14 @@ $(document).mousedown(function(e) {
   if (container.hasClass("active")) {
     if (!container.is(e.target) && container.has(e.target).length === 0) {
       container.removeClass("active");
-      $('#carettab').removeClass("active");
+      $("#carettab").removeClass("active");
     }
   }
 });
 
 // Reset Defaults
-$('#reset').click(function() {
-  var val = confirm('Are you sure you want to reset all settings back to default?');
+$("#reset").click(function() {
+  var val = confirm("Are you sure you want to reset all settings back to default?");
   if (val == true) {
     setDefaults();
     location.reload();

--- a/src/js/app.js
+++ b/src/js/app.js
@@ -12,7 +12,7 @@ console.log("## Created by BlueCaret - http://bluecaret.com/project/carettab");
 console.log("                                        "); 
 
 // Translate HTML via data-i18n attribute
-var objects = document.getElementsByTagName('*'), i;
+var objects = document.getElementsByTagName("*"), i;
 for(i = 0; i < objects.length; i++) {
   if (objects[i].dataset && objects[i].dataset.i18n) {
     objects[i].innerHTML = chrome.i18n.getMessage(objects[i].dataset.i18n);

--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -2,232 +2,232 @@
 // Settings Functions
 // ##############################################
 function tPrimaryClock(loaded) {
-  if (sPrimaryClock == 'on') {
+  if (sPrimaryClock == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sPrimaryClock': 'on'
+        "sPrimaryClock": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sPrimaryClock: on");
         }
       });
     }
-    $('html').addClass('on-clock1');
-    $('#set-clock1').attr('Checked', 'Checked');
+    $("html").addClass("on-clock1");
+    $("#set-clock1").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sPrimaryClock': 'off'
+        "sPrimaryClock": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sPrimaryClock: off");
         }
       });
     }
-    $('html').removeClass('on-clock1');
-    $('#set-clock1').removeAttr('Checked');
+    $("html").removeClass("on-clock1");
+    $("#set-clock1").removeAttr("Checked");
   }
 }
 
 function tSeconds(loaded) {
-  if (sSeconds == 'on') {
+  if (sSeconds == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sSeconds': 'on'
+        "sSeconds": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sSeconds: on");
         }
       });
     }
-    $('html').addClass('on-seconds');
-    $('#set-seconds').attr('Checked', 'Checked');
+    $("html").addClass("on-seconds");
+    $("#set-seconds").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sSeconds': 'off'
+        "sSeconds": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sSeconds: off");
         }
       });
     }
-    $('html').removeClass('on-seconds');
-    $('#set-seconds').removeAttr('Checked');
+    $("html").removeClass("on-seconds");
+    $("#set-seconds").removeAttr("Checked");
   }
 }
 
 function tDimSeconds(loaded) {
-  if (sDimSeconds == 'on') {
+  if (sDimSeconds == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDimSeconds': 'on'
+        "sDimSeconds": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDimSeconds: on");
         }
       });
     }
-    $('html').addClass('on-dimseconds');
-    $('#set-dimseconds').attr('Checked', 'Checked');
+    $("html").addClass("on-dimseconds");
+    $("#set-dimseconds").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDimSeconds': 'off'
+        "sDimSeconds": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDimSeconds: off");
         }
       });
     }
-    $('html').removeClass('on-dimseconds');
-    $('#set-dimseconds').removeAttr('Checked');
+    $("html").removeClass("on-dimseconds");
+    $("#set-dimseconds").removeAttr("Checked");
   }
 }
 
 function tDimDelimiter(loaded) {
-  if (sDimDelimiter == 'on') {
+  if (sDimDelimiter == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDimDelimiter': 'on'
+        "sDimDelimiter": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDimDelimiter: on");
         }
       });
     }
-    $('html').addClass('on-dimdelimiter');
-    $('#set-dimdelimiter').attr('Checked', 'Checked');
+    $("html").addClass("on-dimdelimiter");
+    $("#set-dimdelimiter").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDimDelimiter': 'off'
+        "sDimDelimiter": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDimDelimiter: off");
         }
       });
     }
-    $('html').removeClass('on-dimdelimiter');
-    $('#set-dimdelimiter').removeAttr('Checked');
+    $("html").removeClass("on-dimdelimiter");
+    $("#set-dimdelimiter").removeAttr("Checked");
   }
 }
 
 function tMeridiem(loaded) {
-  if (sMeridiem == 'on') {
+  if (sMeridiem == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sMeridiem': 'on'
+        "sMeridiem": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sMeridiem: on");
         }
       });
     }
-    $('html').addClass('on-meridiem');
-    $('#set-meridiem').attr('Checked', 'Checked');
+    $("html").addClass("on-meridiem");
+    $("#set-meridiem").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sMeridiem': 'off'
+        "sMeridiem": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sMeridiem: off");
         }
       });
     }
-    $('html').removeClass('on-meridiem');
-    $('#set-meridiem').removeAttr('Checked');
+    $("html").removeClass("on-meridiem");
+    $("#set-meridiem").removeAttr("Checked");
   }
 }
 
 function tMilitary(loaded) {
-  if (sMilitary == 'on') {
+  if (sMilitary == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sMilitary': 'on'
+        "sMilitary": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sMilitary: on");
         }
       });
     }
-    $('html').addClass('on-military');
-    $('#set-military').attr('Checked', 'Checked');
+    $("html").addClass("on-military");
+    $("#set-military").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sMilitary': 'off'
+        "sMilitary": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sMilitary: off");
         }
       });
     }
-    $('html').removeClass('on-military');
-    $('#set-military').removeAttr('Checked');
+    $("html").removeClass("on-military");
+    $("#set-military").removeAttr("Checked");
   }
 }
 
 function tDelimiter(loaded) {
-  if (sDelimiter == 'on') {
+  if (sDelimiter == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDelimiter': 'on'
+        "sDelimiter": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDelimiter: on");
         }
       });
     }
-    $('html').addClass('on-delimiter');
-    $('#set-delimiter').attr('Checked', 'Checked');
-    var delimiter = $('#time .delimiter');
+    $("html").addClass("on-delimiter");
+    $("#set-delimiter").attr("Checked", "Checked");
+    var delimiter = $("#time .delimiter");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDelimiter': 'off'
+        "sDelimiter": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDelimiter: off");
         }
       });
     }
-    $('html').removeClass('on-delimiter');
-    $('#set-delimiter').removeAttr('Checked');
-    var delimiter = $('#time .delimiter');
+    $("html").removeClass("on-delimiter");
+    $("#set-delimiter").removeAttr("Checked");
+    var delimiter = $("#time .delimiter");
   }
 }
 
 function tBlinking(loaded) {
-  if (sBlinking == 'on') {
+  if (sBlinking == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sBlinking': 'on'
+        "sBlinking": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sBlinking: on");
         }
       });
     }
-    $('html').addClass('on-blinking');
-    $('#set-blinking').attr('Checked', 'Checked');
+    $("html").addClass("on-blinking");
+    $("#set-blinking").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sBlinking': 'off'
+        "sBlinking": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sBlinking: off");
         }
       });
     }
-    $('html').removeClass('on-blinking');
-    $('#set-blinking').removeAttr('Checked');
-    var delimiter = $('#time .delimiter');
-    if (sDelimiter == 'on') {
+    $("html").removeClass("on-blinking");
+    $("#set-blinking").removeAttr("Checked");
+    var delimiter = $("#time .delimiter");
+    if (sDelimiter == "on") {
       $(delimiter).css({
-        'opacity': ''
+        "opacity": ""
       });
     }
   }
@@ -236,43 +236,43 @@ function tBlinking(loaded) {
 function tPrimaryClockTimezone(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sPrimaryClockTimezone': value
+      "sPrimaryClockTimezone": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sPrimaryClockTimezone: " + value);
       }
     });
   }
-  $('#set-time1-zone').val(value);
+  $("#set-time1-zone").val(value);
 }
 
 function t2ndClock(loaded) {
-  if (s2ndClock == 'on') {
+  if (s2ndClock == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        's2ndClock': 'on'
+        "s2ndClock": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED s2ndClock: on");
         }
       });
     }
-    $('html').addClass('on-clock2');
-    $('#set-time2').attr('Checked', 'Checked');
+    $("html").addClass("on-clock2");
+    $("#set-time2").attr("Checked", "Checked");
     $("#clock2-timezone").slideDown();
     $("#clock2-label").slideDown();
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        's2ndClock': 'off'
+        "s2ndClock": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED s2ndClock: off");
         }
       });
     }
-    $('html').removeClass('on-clock2');
-    $('#set-time2').removeAttr('Checked');
+    $("html").removeClass("on-clock2");
+    $("#set-time2").removeAttr("Checked");
     $("#clock2-timezone").slideUp();
     $("#clock2-label").slideUp();
   }
@@ -281,57 +281,57 @@ function t2ndClock(loaded) {
 function t2ndClockTimezone(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      's2ndClockTimezone': value
+      "s2ndClockTimezone": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED s2ndClockTimezone: " + value);
       }
     });
   }
-  $('#set-time2-zone').val(value);
+  $("#set-time2-zone").val(value);
 }
 
 function t2ndClockLabel(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      's2ndClockLabel': value
+      "s2ndClockLabel": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED s2ndClockLabel: " + value);
       }
     });
   }
-  $('#set-time2-label').val(value);
-  $('#display-clock2-label').text(value);
+  $("#set-time2-label").val(value);
+  $("#display-clock2-label").text(value);
 }
 
 function t3rdClock(loaded) {
-  if (s3rdClock == 'on') {
+  if (s3rdClock == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        's3rdClock': 'on'
+        "s3rdClock": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED s3rdClock: on");
         }
       });
     }
-    $('html').addClass('on-clock3');
-    $('#set-time3').attr('Checked', 'Checked');
+    $("html").addClass("on-clock3");
+    $("#set-time3").attr("Checked", "Checked");
     $("#clock3-timezone").slideDown();
     $("#clock3-label").slideDown();
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        's3rdClock': 'off'
+        "s3rdClock": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED s3rdClock: off");
         }
       });
     }
-    $('html').removeClass('on-clock3');
-    $('#set-time3').removeAttr('Checked');
+    $("html").removeClass("on-clock3");
+    $("#set-time3").removeAttr("Checked");
     $("#clock3-timezone").slideUp();
     $("#clock3-label").slideUp();
   }
@@ -340,57 +340,57 @@ function t3rdClock(loaded) {
 function t3rdClockTimezone(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      's3rdClockTimezone': value
+      "s3rdClockTimezone": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED s3rdClockTimezone: " + value);
       }
     });
   }
-  $('#set-time3-zone').val(value);
+  $("#set-time3-zone").val(value);
 }
 
 function t3rdClockLabel(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      's3rdClockLabel': value
+      "s3rdClockLabel": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED s3rdClockLabel: " + value);
       }
     });
   }
-  $('#set-time3-label').val(value);
-  $('#display-clock3-label').text(value);
+  $("#set-time3-label").val(value);
+  $("#display-clock3-label").text(value);
 }
 
 function t4thClock(loaded) {
-  if (s4thClock == 'on') {
+  if (s4thClock == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        's4thClock': 'on'
+        "s4thClock": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED s4thClock: on");
         }
       });
     }
-    $('html').addClass('on-clock4');
-    $('#set-time4').attr('Checked', 'Checked');
+    $("html").addClass("on-clock4");
+    $("#set-time4").attr("Checked", "Checked");
     $("#clock4-timezone").slideDown();
     $("#clock4-label").slideDown();
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        's4thClock': 'off'
+        "s4thClock": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED s4thClock: off");
         }
       });
     }
-    $('html').removeClass('on-clock4');
-    $('#set-time4').removeAttr('Checked');
+    $("html").removeClass("on-clock4");
+    $("#set-time4").removeAttr("Checked");
     $("#clock4-timezone").slideUp();
     $("#clock4-label").slideUp();
   }
@@ -399,600 +399,600 @@ function t4thClock(loaded) {
 function t4thClockTimezone(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      's4thClockTimezone': value
+      "s4thClockTimezone": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED s4thClockTimezone: " + value);
       }
     });
   }
-  $('#set-time4-zone').val(value);
+  $("#set-time4-zone").val(value);
 }
 
 function t4thClockLabel(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      's4thClockLabel': value
+      "s4thClockLabel": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED s4thClockLabel: " + value);
       }
     });
   }
-  $('#set-time4-label').val(value);
-  $('#display-clock4-label').text(value);
+  $("#set-time4-label").val(value);
+  $("#display-clock4-label").text(value);
 }
 
 function tDate(loaded) {
-  if (sDate == 'on') {
+  if (sDate == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDate': 'on'
+        "sDate": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDate: on");
         }
       });
     }
-    $('html').addClass('on-date');
-    $('#set-date').attr('Checked', 'Checked');
+    $("html").addClass("on-date");
+    $("#set-date").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDate': 'off'
+        "sDate": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDate: off");
         }
       });
     }
-    $('html').removeClass('on-date');
-    $('#set-date').removeAttr('Checked');
+    $("html").removeClass("on-date");
+    $("#set-date").removeAttr("Checked");
   }
 }
 
 function tDay(loaded) {
-  if (sDay == 'on') {
+  if (sDay == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDay': 'on'
+        "sDay": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDay: on");
         }
       });
     }
-    $('html').addClass('on-day');
-    $('#set-day').attr('Checked', 'Checked');
+    $("html").addClass("on-day");
+    $("#set-day").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDay': 'off'
+        "sDay": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDay: off");
         }
       });
     }
-    $('html').removeClass('on-day');
-    $('#set-day').removeAttr('Checked');
+    $("html").removeClass("on-day");
+    $("#set-day").removeAttr("Checked");
   }
 }
 
 function tYear(loaded) {
-  if (sYear == 'on') {
+  if (sYear == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sYear': 'on'
+        "sYear": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sYear: on");
         }
       });
     }
-    $('html').addClass('on-year');
-    $('#set-year').attr('Checked', 'Checked');
+    $("html").addClass("on-year");
+    $("#set-year").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sYear': 'off'
+        "sYear": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sYear: off");
         }
       });
     }
-    $('html').removeClass('on-year');
-    $('#set-year').removeAttr('Checked');
+    $("html").removeClass("on-year");
+    $("#set-year").removeAttr("Checked");
   }
 }
 
 function tShortDate(loaded) {
-  if (sShortDate == 'on') {
+  if (sShortDate == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sShortDate': 'on'
+        "sShortDate": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sShortDate: on");
         }
       });
     }
-    $('html').addClass('on-shortdate');
-    $('#set-shortdate').attr('Checked', 'Checked');
+    $("html").addClass("on-shortdate");
+    $("#set-shortdate").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sShortDate': 'off'
+        "sShortDate": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sShortDate: off");
         }
       });
     }
-    $('html').removeClass('on-shortdate');
-    $('#set-shortdate').removeAttr('Checked');
+    $("html").removeClass("on-shortdate");
+    $("#set-shortdate").removeAttr("Checked");
   }
 }
 
 function tDateFormat(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sDateFormat': sDateFormat
+      "sDateFormat": sDateFormat
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sDateFormat: " + sDateFormat);
       }
     });
   }
-  $('#set-dateformat').val(value);
+  $("#set-dateformat").val(value);
 }
 
 function tWeek(loaded) {
-  if (sWeek == 'on') {
+  if (sWeek == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sWeek': 'on'
+        "sWeek": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sWeek: on");
         }
       });
     }
-    $('html').addClass('on-week');
-    $('#set-week').attr('Checked', 'Checked');
+    $("html").addClass("on-week");
+    $("#set-week").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sWeek': 'off'
+        "sWeek": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sWeek: off");
         }
       });
     }
-    $('html').removeClass('on-week');
-    $('#set-week').removeAttr('Checked');
+    $("html").removeClass("on-week");
+    $("#set-week").removeAttr("Checked");
   }
 }
 
 function tBackground(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sBackground': value
+      "sBackground": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sBackground: " + value);
       }
     });
   }
-  $('#set-background').val(value);
-  $('#set-background-value').val(value);
-  $('body').css({
-    'background-color': value
+  $("#set-background").val(value);
+  $("#set-background-value").val(value);
+  $("body").css({
+    "background-color": value
   });
 }
 
 function tForeground(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sForeground': value
+      "sForeground": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sForeground: " + value);
       }
     });
   }
-  var searchDiv = $('#search');
-  var analogDiv = $('#analog');
-  $('#set-foreground').val(value);
-  $('#set-foreground-value').val(value);
-  $('body').css({
-    'color': value
+  var searchDiv = $("#search");
+  var analogDiv = $("#analog");
+  $("#set-foreground").val(value);
+  $("#set-foreground-value").val(value);
+  $("body").css({
+    "color": value
   });
-  $('#carettab').find('a').css({
-    'color': value
+  $("#carettab").find("a").css({
+    "color": value
   });
   searchDiv.css({
-    'border-color': value,
-    'color': value
+    "border-color": value,
+    "color": value
   });
-  searchDiv.find('input').css({
-    'border-color': value,
-    'color': value
+  searchDiv.find("input").css({
+    "border-color": value,
+    "color": value
   });
-  searchDiv.find('button').css({
-    'border-color': value,
+  searchDiv.find("button").css({
+    "border-color": value,
   });
-  searchDiv.find('button svg').css({
-    'fill': value
+  searchDiv.find("button svg").css({
+    "fill": value
   });
-  $('#settings-toggle').find('.st0').css({
-    'fill': value
+  $("#settings-toggle").find(".st0").css({
+    "fill": value
   });
-  analogDiv.find('circle').css({
-    'fill': value
+  analogDiv.find("circle").css({
+    "fill": value
   });
-  analogDiv.find('ellipse').css({
-    'fill': value
+  analogDiv.find("ellipse").css({
+    "fill": value
   });
-  analogDiv.find('.analog-face div').css({
-    'background': value
+  analogDiv.find(".analog-face div").css({
+    "background": value
   });
 }
 
 function tTabTitle(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sTabTitle': sTabTitle
+      "sTabTitle": sTabTitle
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sTabTitle: " + sTabTitle);
       }
     });
   }
-  $('#set-tab-title').val(value);
+  $("#set-tab-title").val(value);
 }
 
 function tTabTitleCustomMessage(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sTabTitleCustomMessage': value
+      "sTabTitleCustomMessage": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sTabTitleCustomMessage: " + value);
       }
     });
   }
-  $('#set-tab-custom-message').val(value);
+  $("#set-tab-custom-message").val(value);
 }
 
 function tCustomMessage(loaded) {
-  if (sCustomMessage == 'on') {
+  if (sCustomMessage == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sCustomMessage': 'on'
+        "sCustomMessage": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sCustomMessage: on");
         }
       });
     }
-    $('html').addClass('on-message');
-    $('#set-message').attr('Checked', 'Checked');
+    $("html").addClass("on-message");
+    $("#set-message").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sCustomMessage': 'off'
+        "sCustomMessage": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sCustomMessage: off");
         }
       });
     }
-    $('html').removeClass('on-message');
-    $('#set-message').removeAttr('Checked');
+    $("html").removeClass("on-message");
+    $("#set-message").removeAttr("Checked");
   }
 }
 
 function tCustomMessageText(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sCustomMessageText': value
+      "sCustomMessageText": value
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sCustomMessageText: " + value);
       }
     });
   }
-  $('#set-message-text').val(value);
-  $('#message').text(value);
+  $("#set-message-text").val(value);
+  $("#message").text(value);
 }
 
 function tSearch(loaded) {
-  if (sSearch == 'on') {
+  if (sSearch == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sSearch': 'on'
+        "sSearch": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sSearch: on");
         }
       });
     }
-    $('html').addClass('on-search');
-    $('#set-search').attr('Checked', 'Checked');
+    $("html").addClass("on-search");
+    $("#set-search").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sSearch': 'off'
+        "sSearch": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sSearch: off");
         }
       });
     }
-    $('html').removeClass('on-search');
-    $('#set-search').removeAttr('Checked');
+    $("html").removeClass("on-search");
+    $("#set-search").removeAttr("Checked");
   }
 }
 
 function tEngine(value, loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sEngine': sEngine
+      "sEngine": sEngine
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sEngine:" + sEngine);
       }
     });
   }
-  $('#set-engine').val(value);
+  $("#set-engine").val(value);
   if (sEngine == "bing") {
-    $('#search').attr('action', 'http://www.bing.com/search');
-    $('#search-box').attr('placeholder', 'Bing');
-    $('#search-box').attr('name', 'q');
+    $("#search").attr("action", "http://www.bing.com/search");
+    $("#search-box").attr("placeholder", "Bing");
+    $("#search-box").attr("name", "q");
   } else if (sEngine == "baidu") {
-    $('#search').attr('action', 'http://www.baidu.com/s');
-    $('#search-box').attr('placeholder', 'Baidu');
-    $('#search-box').attr('name', 'wd');
+    $("#search").attr("action", "http://www.baidu.com/s");
+    $("#search-box").attr("placeholder", "Baidu");
+    $("#search-box").attr("name", "wd");
   } else if (sEngine == "yahoo") {
-    $('#search').attr('action', 'http://search.yahoo.com/search');
-    $('#search-box').attr('placeholder', 'Yahoo');
-    $('#search-box').attr('name', 'p');
+    $("#search").attr("action", "http://search.yahoo.com/search");
+    $("#search-box").attr("placeholder", "Yahoo");
+    $("#search-box").attr("name", "p");
   } else if (sEngine == "ask") {
-    $('#search').attr('action', 'http://www.ask.com/web');
-    $('#search-box').attr('placeholder', 'Ask.com');
-    $('#search-box').attr('name', 'q');
+    $("#search").attr("action", "http://www.ask.com/web");
+    $("#search-box").attr("placeholder", "Ask.com");
+    $("#search-box").attr("name", "q");
   } else if (sEngine == "duckduckgo") {
-    $('#search').attr('action', 'http://www.duckduckgo.com/');
-    $('#search-box').attr('placeholder', 'DuckDuckGo');
-    $('#search-box').attr('name', 'q');
+    $("#search").attr("action", "http://www.duckduckgo.com/");
+    $("#search-box").attr("placeholder", "DuckDuckGo");
+    $("#search-box").attr("name", "q");
   } else if (sEngine == "wolframalpha") {
-    $('#search').attr('action', 'http://www.wolframalpha.com/input/');
-    $('#search-box').attr('placeholder', 'Wolframalpha');
-    $('#search-box').attr('name', 'i');
+    $("#search").attr("action", "http://www.wolframalpha.com/input/");
+    $("#search-box").attr("placeholder", "Wolframalpha");
+    $("#search-box").attr("name", "i");
   } else if (sEngine == "github") {
-    $('#search').attr('action', 'https://www.github.com/search');
-    $('#search-box').attr('placeholder', 'GitHub');
-    $('#search-box').attr('name', 'q');
+    $("#search").attr("action", "https://www.github.com/search");
+    $("#search-box").attr("placeholder", "GitHub");
+    $("#search-box").attr("name", "q");
   } else {
-    $('#search').attr('action', 'https://www.google.com/search');
-    $('#search-box').attr('placeholder', 'Google');
-    $('#search-box').attr('name', 'q');
+    $("#search").attr("action", "https://www.google.com/search");
+    $("#search-box").attr("placeholder", "Google");
+    $("#search-box").attr("name", "q");
   }
 }
 
 function tAnimation(loaded) {
-  if (sAnimation == 'on') {
+  if (sAnimation == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sAnimation': 'on'
+        "sAnimation": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sAnimation: on");
         }
       });
     }
-    $('html').addClass('on-animation');
-    $('#set-animation').attr('Checked', 'Checked');
+    $("html").addClass("on-animation");
+    $("#set-animation").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sAnimation': 'off'
+        "sAnimation": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sAnimation: off");
         }
       });
     }
-    $('html').removeClass('on-animation');
-    $('#set-animation').removeAttr('Checked');
+    $("html").removeClass("on-animation");
+    $("#set-animation").removeAttr("Checked");
   }
 }
 
 function tScale(loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sScale': sScale
+      "sScale": sScale
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sScale: " + sScale);
       }
     });
   }
-  $('input[name="set-scale"]').val(sScale);
-  $('#carettab').css('font-size', sScale + 'vw');
+  $("input[name=\"set-scale\"]").val(sScale);
+  $("#carettab").css("font-size", sScale + "vw");
 }
 
 function tBrackets(loaded) {
-  if (sBrackets == 'on') {
+  if (sBrackets == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sBrackets': 'on'
+        "sBrackets": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sBrackets: on");
         }
       });
     }
-    $('html').addClass('on-brackets');
-    $('#set-brackets').attr('Checked', 'Checked');
+    $("html").addClass("on-brackets");
+    $("#set-brackets").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sBrackets': 'off'
+        "sBrackets": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sBrackets: off");
         }
       });
     }
-    $('html').removeClass('on-brackets');
-    $('#set-brackets').removeAttr('Checked');
+    $("html").removeClass("on-brackets");
+    $("#set-brackets").removeAttr("Checked");
   }
 }
 
 function tDimBrackets(loaded) {
-  if (sDimBrackets == 'on') {
+  if (sDimBrackets == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDimBrackets': 'on'
+        "sDimBrackets": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDimBrackets: on");
         }
       });
     }
-    $('html').addClass('on-dimbrackets');
-    $('#set-dimbrackets').attr('Checked', 'Checked');
+    $("html").addClass("on-dimbrackets");
+    $("#set-dimbrackets").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sDimBrackets': 'off'
+        "sDimBrackets": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sDimBrackets: off");
         }
       });
     }
-    $('html').removeClass('on-dimbrackets');
-    $('#set-dimbrackets').removeAttr('Checked');
+    $("html").removeClass("on-dimbrackets");
+    $("#set-dimbrackets").removeAttr("Checked");
   }
 }
 
 function tBracketStyle(loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sBracketStyle': sBracketStyle
+      "sBracketStyle": sBracketStyle
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sBracketStyle: " + sBracketStyle);
       }
     });
   }
-  $('input[name="set-bracket-style"][value="' + sBracketStyle + '"]').attr('Checked', 'Checked');
-  $('html').removeClass("brackets-curly brackets-square brackets-straight brackets-paran brackets-slash");
-  $('html').addClass('brackets-' + sBracketStyle + '');
+  $("input[name=\"set-bracket-style\"][value=\"" + sBracketStyle + "\"]").attr("Checked", "Checked");
+  $("html").removeClass("brackets-curly brackets-square brackets-straight brackets-paran brackets-slash");
+  $("html").addClass("brackets-" + sBracketStyle + "");
 }
 
 function tDateDelimiter(loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sDateDelimiter': sDateDelimiter
+      "sDateDelimiter": sDateDelimiter
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sDateDelimiter: " + sDateDelimiter);
       }
     });
   }
-  $('input[name="set-date-delimiter"][value="' + sDateDelimiter + '"]').attr('Checked', 'Checked');
-  $('html').removeClass("date-delimiter-slash date-delimiter-period date-delimiter-dash date-delimiter-space");
-  $('html').addClass('date-delimiter-' + sDateDelimiter + '');
+  $("input[name=\"set-date-delimiter\"][value=\"" + sDateDelimiter + "\"]").attr("Checked", "Checked");
+  $("html").removeClass("date-delimiter-slash date-delimiter-period date-delimiter-dash date-delimiter-space");
+  $("html").addClass("date-delimiter-" + sDateDelimiter + "");
 }
 
 function tWeekLabel(loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sWeekLabel': sWeekLabel
+      "sWeekLabel": sWeekLabel
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sWeekLabel: " + sWeekLabel);
       }
     });
   }
-  $('input[name="set-week-label"][value="' + sWeekLabel + '"]').attr('Checked', 'Checked');
-  $('html').removeClass("week-label-week week-label-wk week-label-pound week-label-none");
-  $('html').addClass('week-label-' + sWeekLabel + '');
+  $("input[name=\"set-week-label\"][value=\"" + sWeekLabel + "\"]").attr("Checked", "Checked");
+  $("html").removeClass("week-label-week week-label-wk week-label-pound week-label-none");
+  $("html").addClass("week-label-" + sWeekLabel + "");
 }
 
 function tFont(loaded) {
   if (loaded != true) {
     chrome.storage.sync.set({
-      'sFont': sFont
+      "sFont": sFont
     }, function() {
       if (!chrome.runtime.lastError) {
         console.log("^CaretTab - SAVED sFont: " + sFont);
       }
     });
   }
-  $('input[name="set-font"][value="' + sFont + '"]').attr('Checked', 'Checked');
-  $('body').removeClass("font-exo-2 font-quicksand font-amatic-sc font-anton font-eb-garamond font-lobster font-monoton font-press-start-2p font-special-elite");
-  $('body').addClass('font-' + sFont + '');
+  $("input[name=\"set-font\"][value=\"" + sFont + "\"]").attr("Checked", "Checked");
+  $("body").removeClass("font-exo-2 font-quicksand font-amatic-sc font-anton font-eb-garamond font-lobster font-monoton font-press-start-2p font-special-elite");
+  $("body").addClass("font-" + sFont + "");
 }
 
 function tHideSettingsToggle(loaded) {
-  if (sHideSettingsToggle == 'on') {
+  if (sHideSettingsToggle == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sHideSettingsToggle': 'on'
+        "sHideSettingsToggle": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sHideSettingsToggle: on");
         }
       });
     }
-    $('html').removeClass('on-settings-toggle');
-    $('#set-hide-settings-toggle').attr('Checked', 'Checked');
+    $("html").removeClass("on-settings-toggle");
+    $("#set-hide-settings-toggle").attr("Checked", "Checked");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sHideSettingsToggle': 'off'
+        "sHideSettingsToggle": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sHideSettingsToggle: off");
         }
       });
     }
-    $('html').addClass('on-settings-toggle');
-    $('#set-hide-settings-toggle').removeAttr('Checked');
+    $("html").addClass("on-settings-toggle");
+    $("#set-hide-settings-toggle").removeAttr("Checked");
   }
 }
 
 function tAnalog(loaded) {
-  if (sAnalog == 'on') {
+  if (sAnalog == "on") {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sAnalog': 'on'
+        "sAnalog": "on"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sAnalog: on");
         }
       });
     }
-    $('#set-analog').removeAttr('Checked');
-    $('html').addClass('on-analog');
+    $("#set-analog").removeAttr("Checked");
+    $("html").addClass("on-analog");
   } else {
     if (loaded != true) {
       chrome.storage.sync.set({
-        'sAnalog': 'off'
+        "sAnalog": "off"
       }, function() {
         if (!chrome.runtime.lastError) {
           console.log("^CaretTab - SAVED sAnalog: off");
         }
       });
     }
-    $('html').removeClass('on-analog');
-    $('#set-analog').attr('Checked', 'Checked');
+    $("html").removeClass("on-analog");
+    $("#set-analog").attr("Checked", "Checked");
   }
 }

--- a/src/js/install_status.js
+++ b/src/js/install_status.js
@@ -9,9 +9,9 @@ $(function() {
     // Check if extension was just installed or updated
     var caretTabStatus = data.caretTabStatus;
     console.log("^CaretTab - Status: " + caretTabStatus);
-    if (caretTabStatus == 'installed') {
+    if (caretTabStatus == "installed") {
       $("#installed").show();
-    } else if (caretTabStatus == 'updated') {
+    } else if (caretTabStatus == "updated") {
       $("#updated").show();
     }
 

--- a/src/js/links.js
+++ b/src/js/links.js
@@ -1,53 +1,53 @@
 var storage = chrome.storage.sync;
 var err = chrome.runtime.lastError;
-var addBtn = document.getElementById('s-link-add');
-var newLabel = document.getElementById('s-link-label');
-var newUrl = document.getElementById('s-link-url');
+var addBtn = document.getElementById("s-link-add");
+var newLabel = document.getElementById("s-link-label");
+var newUrl = document.getElementById("s-link-url");
 
 // Temp code to pull in old links and add to new links
 storage.get([
-  'links',
-  's1stLink','s1stLinkLabel','s1stLinkUrl',
-  's2ndLink','s2ndLinkLabel','s2ndLinkUrl',
-  's3rdLink','s3rdLinkLabel','s3rdLinkUrl',
-  's4thLink','s4thLinkLabel','s4thLinkUrl',
-  's5thLink','s5thLinkLabel','s5thLinkUrl',
-  's6thLink','s6thLinkLabel','s6thLinkUrl'
-  ], function(data) {
+  "links",
+  "s1stLink","s1stLinkLabel","s1stLinkUrl",
+  "s2ndLink","s2ndLinkLabel","s2ndLinkUrl",
+  "s3rdLink","s3rdLinkLabel","s3rdLinkUrl",
+  "s4thLink","s4thLinkLabel","s4thLinkUrl",
+  "s5thLink","s5thLinkLabel","s5thLinkUrl",
+  "s6thLink","s6thLinkLabel","s6thLinkUrl"
+], function(data) {
   var allLinks = data.links ? data.links : [];
-  if (data.s1stLink == 'on' && data.s1stLinkLabel && data.s1stLinkUrl) {
+  if (data.s1stLink == "on" && data.s1stLinkLabel && data.s1stLinkUrl) {
     var link1 = new link(data.s1stLinkLabel, data.s1stLinkUrl);
     allLinks.push(link1);
   }
-  if (data.s2ndLink == 'on' && data.s2ndLinkLabel && data.s2ndLinkUrl) {
+  if (data.s2ndLink == "on" && data.s2ndLinkLabel && data.s2ndLinkUrl) {
     var link2 = new link(data.s2ndLinkLabel, data.s2ndLinkUrl);
     allLinks.push(link2);
   }
-  if (data.s3rdLink == 'on' && data.s3rdLinkLabel && data.s3rdLinkUrl) {
+  if (data.s3rdLink == "on" && data.s3rdLinkLabel && data.s3rdLinkUrl) {
     var link3 = new link(data.s3rdLinkLabel, data.s3rdLinkUrl);
     allLinks.push(link3);
   }
-  if (data.s4thLink == 'on' && data.s4thLinkLabel && data.s4thLinkUrl) {
+  if (data.s4thLink == "on" && data.s4thLinkLabel && data.s4thLinkUrl) {
     var link4 = new link(data.s4thLinkLabel, data.s4thLinkUrl);
     allLinks.push(link4);
   }
-  if (data.s5thLink == 'on' && data.s5thLinkLabel && data.s5thLinkUrl) {
+  if (data.s5thLink == "on" && data.s5thLinkLabel && data.s5thLinkUrl) {
     var link5 = new link(data.s5thLinkLabel, data.s5thLinkUrl);
     allLinks.push(link5);
   }
-  if (data.s6thLink == 'on' && data.s6thLinkLabel && data.s6thLinkUrl) {
+  if (data.s6thLink == "on" && data.s6thLinkLabel && data.s6thLinkUrl) {
     var link6 = new link(data.s6thLinkLabel, data.s6thLinkUrl);
     allLinks.push(link6);
   }
-  storage.set({'links': allLinks }, function() { if (err) { console.log('Error Saving Link: ' + err); } });
+  storage.set({"links": allLinks }, function() { if (err) { console.log("Error Saving Link: " + err); } });
   storage.remove([
-    's1stLink','s1stLinkLabel','s1stLinkUrl',
-    's2ndLink','s2ndLinkLabel','s2ndLinkUrl',
-    's3rdLink','s3rdLinkLabel','s3rdLinkUrl',
-    's4thLink','s4thLinkLabel','s4thLinkUrl',
-    's5thLink','s5thLinkLabel','s5thLinkUrl',
-    's6thLink','s6thLinkLabel','s6thLinkUrl'
-  ], function() { if (err) { console.log('Error Removing Old Links: ' + err); } });
+    "s1stLink","s1stLinkLabel","s1stLinkUrl",
+    "s2ndLink","s2ndLinkLabel","s2ndLinkUrl",
+    "s3rdLink","s3rdLinkLabel","s3rdLinkUrl",
+    "s4thLink","s4thLinkLabel","s4thLinkUrl",
+    "s5thLink","s5thLinkLabel","s5thLinkUrl",
+    "s6thLink","s6thLinkLabel","s6thLinkUrl"
+  ], function() { if (err) { console.log("Error Removing Old Links: " + err); } });
   showLinksInterface();
   showLinksSettings();
 });
@@ -58,16 +58,16 @@ function link (theLabel, theUrl) {
 }
 
 function add() {
-  storage.get('links', function(data) {
+  storage.get("links", function(data) {
     var allLinks = data.links ? data.links : [];
     var checkedNewUrl = checkLink(newUrl.value);
     var newLink = new link(newLabel.value, checkedNewUrl);
 
     allLinks.push(newLink);
-    storage.set({'links': allLinks }, function() { if (err) { console.log('Error Saving Link: ' + err); } });
+    storage.set({"links": allLinks }, function() { if (err) { console.log("Error Saving Link: " + err); } });
 
-    newLabel.value = '';
-    newUrl.value = '';
+    newLabel.value = "";
+    newUrl.value = "";
 
     showLinksInterface();
     showLinksSettings();
@@ -75,17 +75,17 @@ function add() {
 }
 
 function remove() {
-  var id = this.getAttribute('id').replace('s-link-remove-','');
-  storage.get('links', function(data) {
+  var id = this.getAttribute("id").replace("s-link-remove-","");
+  storage.get("links", function(data) {
     var allLinks = data.links ? data.links : [];
 
     for(var i = 0; i < allLinks.length; i++) {
       if (i == id) {
         allLinks.splice(i, 1);
       }
-    };
+    }
 
-    storage.set({'links': allLinks }, function() { if (err) { console.log('Error Removing Link: ' + err); } });
+    storage.set({"links": allLinks }, function() { if (err) { console.log("Error Removing Link: " + err); } });
 
     showLinksInterface();
     showLinksSettings();
@@ -93,11 +93,11 @@ function remove() {
 }
 
 function edit() {
-  var id = this.getAttribute('id').replace('s-link-edit-','');
-  var editLabel = document.getElementById('s-link-label-'+id);
-  var editUrl = document.getElementById('s-link-url-'+id);
+  var id = this.getAttribute("id").replace("s-link-edit-","");
+  var editLabel = document.getElementById("s-link-label-"+id);
+  var editUrl = document.getElementById("s-link-url-"+id);
 
-  storage.get('links', function(data) {
+  storage.get("links", function(data) {
     var allLinks = data.links ? data.links : [];
     var editLink = new link(editLabel.value, editUrl.value);
 
@@ -105,9 +105,9 @@ function edit() {
       if (i == id) {
         allLinks[i] = editLink;
       }
-    };
+    }
     
-    storage.set({'links': allLinks }, function() { if (err) { console.log('Error Editing Link: ' + err); } });
+    storage.set({"links": allLinks }, function() { if (err) { console.log("Error Editing Link: " + err); } });
 
     showLinksInterface();
     showLinksSettings();
@@ -115,68 +115,68 @@ function edit() {
 }
 
 function showLinksInterface() {
-  storage.get('links', function(data) {
+  storage.get("links", function(data) {
     var allLinks = data.links;
 
     if (allLinks != undefined) {
-      var html = ''
+      var html = "";
 
       for(var i = 0; i < allLinks.length; i++) {
-        html += '<a href="' + allLinks[i].url + '" id="i-link-' + i  + '" class="link">' + allLinks[i].label + '</a>';
-      };
+        html += "<a href=\"" + allLinks[i].url + "\" id=\"i-link-" + i  + "\" class=\"link\">" + allLinks[i].label + "</a>";
+      }
 
-      document.getElementById('links').innerHTML = html;
+      document.getElementById("links").innerHTML = html;
     }
   });
 }
 
 function showLinksSettings() {
-  storage.get('links', function(data) {
+  storage.get("links", function(data) {
     var allLinks = data.links;
 
     if (allLinks != undefined) {
-      var html = '';
+      var html = "";
       
       for(var i = 0; i < allLinks.length; i++) {
-        html += '<div id="s-link-' + i  + '" class="row">';
-        html += '  <div class="label">';
-        html += '    <span data-i18n="'+ chrome.i18n.getMessage("link") +' ">Link </span>' + (i + 1);
-        html += '  </div>';
-        html += '  <div class="input input-text" style="width:30%">';
-        html += '    <input id="s-link-label-' + i  + '" type="text" value="' + allLinks[i].label + '">';
-        html += '  </div>';
-        html += '  <div class="input input-text" style="width:30%">';
-        html += '    <input id="s-link-url-' + i  + '" type="text" value="' + allLinks[i].url + '">';
-        html += '  </div>';
-        html += '  <div class="label" style="flex: 0 0 auto;">';
-        html += '    <button class="edit-link btn" id="s-link-edit-' + i  + '">&#9998;</button>';
-        html += '    <button class="remove-link btn" id="s-link-remove-' + i  + '">&#10006;</button>';
-        html += '  </div>';
-        html += '</div>';
-      };
+        html += "<div id=\"s-link-" + i  + "\" class=\"row\">";
+        html += "  <div class=\"label\">";
+        html += "    <span data-i18n=\""+ chrome.i18n.getMessage("link") +" \">Link </span>" + (i + 1);
+        html += "  </div>";
+        html += "  <div class=\"input input-text\" style=\"width:30%\">";
+        html += "    <input id=\"s-link-label-" + i  + "\" type=\"text\" value=\"" + allLinks[i].label + "\">";
+        html += "  </div>";
+        html += "  <div class=\"input input-text\" style=\"width:30%\">";
+        html += "    <input id=\"s-link-url-" + i  + "\" type=\"text\" value=\"" + allLinks[i].url + "\">";
+        html += "  </div>";
+        html += "  <div class=\"label\" style=\"flex: 0 0 auto;\">";
+        html += "    <button class=\"edit-link btn\" id=\"s-link-edit-" + i  + "\">&#9998;</button>";
+        html += "    <button class=\"remove-link btn\" id=\"s-link-remove-" + i  + "\">&#10006;</button>";
+        html += "  </div>";
+        html += "</div>";
+      }
 
-      document.getElementById('s-links').innerHTML = html;
+      document.getElementById("s-links").innerHTML = html;
 
-      var removeBtns = document.getElementsByClassName('remove-link');
+      var removeBtns = document.getElementsByClassName("remove-link");
       for (var i=0; i < removeBtns.length; i++) {
-        removeBtns[i].addEventListener('click', remove);
-      };
+        removeBtns[i].addEventListener("click", remove);
+      }
 
-      var editBtns = document.getElementsByClassName('edit-link');
+      var editBtns = document.getElementsByClassName("edit-link");
       for (var i=0; i < editBtns.length; i++) {
-        editBtns[i].addEventListener('click', edit);
-      };
-    };
+        editBtns[i].addEventListener("click", edit);
+      }
+    }
   });
 }
 
 function checkLink(value, loaded) {
   if (value != undefined) {
-    value = (value.indexOf('//') === -1) ? 'http://' + value : value;
+    value = (value.indexOf("//") === -1) ? "http://" + value : value;
   }
   return value;
 }
 
-addBtn.addEventListener('click', add);
+addBtn.addEventListener("click", add);
 showLinksInterface();
 showLinksSettings();

--- a/src/js/load.js
+++ b/src/js/load.js
@@ -1,39 +1,39 @@
-var timezoneOptions = '\
-  <option value="Pacific/Midway">(GMT -11:00) Midway Island, Samoa</option>\
-  <option value="Pacific/Honolulu">(GMT -10:00) Hawaii</option>\
-  <option value="America/Anchorage">(GMT -9:00) Alaska</option>\
-  <option value="America/Los_Angeles">(GMT -8:00) Pacific Time (US &amp; Canada)</option>\
-  <option value="America/Boise">(GMT -7:00) Mountain Time (US &amp; Canada)</option>\
-  <option value="America/Phoenix">(GMT -7:00) Mountain Standard Time (US &amp; Canada), America/Phoenix</option>\
-  <option value="America/Chicago">(GMT -6:00) Central Time (US &amp; Canada), Mexico City</option>\
-  <option value="America/Belize">(GMT -6:00) Central Standard Time (America), Belize, Costa Rica</option>\
-  <option value="America/New_York">(GMT -5:00) Eastern Time (US &amp; Canada), Bogota, Lima</option>\
-  <option value="Atlantic/Bermuda">(GMT -4:00) Atlantic Time (Canada), Canada/Atlantic</option>\
-  <option value="Canada/Newfoundland">(GMT -3:30) Newfoundland</option>\
-  <option value="America/Argentina/Buenos_Aires">(GMT -3:00) Brazil, Buenos Aires, Georgetown</option>\
-  <option value="Atlantic/South_Georgia">(GMT -2:00) Mid-Atlantic</option>\
-  <option value="Atlantic/Azores">(GMT -1:00 hour) Azores, Cape Verde Islands</option>\
-  <option value="Europe/London">(GMT) Western Europe Time, London, Lisbon, Casablanca</option>\
-  <option value="Europe/Paris">(GMT +1:00 hour) Brussels, Copenhagen, Madrid, Paris</option>\
-  <option value="Europe/Kaliningrad">(GMT +2:00) Kaliningrad, South Africa</option>\
-  <option value="Asia/Baghdad">(GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg</option>\
-  <option value="Asia/Tehran">(GMT +3:30) Tehran</option>\
-  <option value="Asia/Muscat">(GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi</option>\
-  <option value="Asia/Kabul">(GMT +4:30) Kabul</option>\
-  <option value="Asia/Karachi">(GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent</option>\
-  <option value="Asia/Calcutta">(GMT +5:30) Bombay, Calcutta, Madras, New Delhi</option>\
-  <option value="Asia/Kathmandu">(GMT +5:45) Kathmandu</option>\
-  <option value="Asia/Almaty">(GMT +6:00) Almaty, Dhaka, Colombo</option>\
-  <option value="Asia/Bangkok">(GMT +7:00) Bangkok, Hanoi, Jakarta</option>\
-  <option value="Asia/Hong_Kong">(GMT +8:00) Beijing, Perth, Singapore, Hong Kong</option>\
-  <option value="Asia/Tokyo">(GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk</option>\
-  <option value="Australia/Adelaide">(GMT +9:30) Adelaide, Darwin</option>\
-  <option value="Pacific/Guam">(GMT +10:00) Eastern Australia, Guam, Vladivostok</option>\
-  <option value="Asia/Magadan">(GMT +11:00) Magadan, Solomon Islands, New Caledonia</option>\
-  <option value="Pacific/Auckland">(GMT +12:00) Auckland, Wellington, Fiji, Kamchatka</option>\
-  ';
+var timezoneOptions = "\
+  <option value=\"Pacific/Midway\">(GMT -11:00) Midway Island, Samoa</option>\
+  <option value=\"Pacific/Honolulu\">(GMT -10:00) Hawaii</option>\
+  <option value=\"America/Anchorage\">(GMT -9:00) Alaska</option>\
+  <option value=\"America/Los_Angeles\">(GMT -8:00) Pacific Time (US &amp; Canada)</option>\
+  <option value=\"America/Boise\">(GMT -7:00) Mountain Time (US &amp; Canada)</option>\
+  <option value=\"America/Phoenix\">(GMT -7:00) Mountain Standard Time (US &amp; Canada), America/Phoenix</option>\
+  <option value=\"America/Chicago\">(GMT -6:00) Central Time (US &amp; Canada), Mexico City</option>\
+  <option value=\"America/Belize\">(GMT -6:00) Central Standard Time (America), Belize, Costa Rica</option>\
+  <option value=\"America/New_York\">(GMT -5:00) Eastern Time (US &amp; Canada), Bogota, Lima</option>\
+  <option value=\"Atlantic/Bermuda\">(GMT -4:00) Atlantic Time (Canada), Canada/Atlantic</option>\
+  <option value=\"Canada/Newfoundland\">(GMT -3:30) Newfoundland</option>\
+  <option value=\"America/Argentina/Buenos_Aires\">(GMT -3:00) Brazil, Buenos Aires, Georgetown</option>\
+  <option value=\"Atlantic/South_Georgia\">(GMT -2:00) Mid-Atlantic</option>\
+  <option value=\"Atlantic/Azores\">(GMT -1:00 hour) Azores, Cape Verde Islands</option>\
+  <option value=\"Europe/London\">(GMT) Western Europe Time, London, Lisbon, Casablanca</option>\
+  <option value=\"Europe/Paris\">(GMT +1:00 hour) Brussels, Copenhagen, Madrid, Paris</option>\
+  <option value=\"Europe/Kaliningrad\">(GMT +2:00) Kaliningrad, South Africa</option>\
+  <option value=\"Asia/Baghdad\">(GMT +3:00) Baghdad, Riyadh, Moscow, St. Petersburg</option>\
+  <option value=\"Asia/Tehran\">(GMT +3:30) Tehran</option>\
+  <option value=\"Asia/Muscat\">(GMT +4:00) Abu Dhabi, Muscat, Baku, Tbilisi</option>\
+  <option value=\"Asia/Kabul\">(GMT +4:30) Kabul</option>\
+  <option value=\"Asia/Karachi\">(GMT +5:00) Ekaterinburg, Islamabad, Karachi, Tashkent</option>\
+  <option value=\"Asia/Calcutta\">(GMT +5:30) Bombay, Calcutta, Madras, New Delhi</option>\
+  <option value=\"Asia/Kathmandu\">(GMT +5:45) Kathmandu</option>\
+  <option value=\"Asia/Almaty\">(GMT +6:00) Almaty, Dhaka, Colombo</option>\
+  <option value=\"Asia/Bangkok\">(GMT +7:00) Bangkok, Hanoi, Jakarta</option>\
+  <option value=\"Asia/Hong_Kong\">(GMT +8:00) Beijing, Perth, Singapore, Hong Kong</option>\
+  <option value=\"Asia/Tokyo\">(GMT +9:00) Tokyo, Seoul, Osaka, Sapporo, Yakutsk</option>\
+  <option value=\"Australia/Adelaide\">(GMT +9:30) Adelaide, Darwin</option>\
+  <option value=\"Pacific/Guam\">(GMT +10:00) Eastern Australia, Guam, Vladivostok</option>\
+  <option value=\"Asia/Magadan\">(GMT +11:00) Magadan, Solomon Islands, New Caledonia</option>\
+  <option value=\"Pacific/Auckland\">(GMT +12:00) Auckland, Wellington, Fiji, Kamchatka</option>\
+  ";
 $(function() {
-  $('.timezones').html(timezoneOptions);
+  $(".timezones").html(timezoneOptions);
 });
 
 // ##############################################
@@ -214,7 +214,7 @@ function loadSettings(caretTabStatus, sLoad, data, loaded) {
   tAnalog(loaded);
 
   // Run updateAll on load
-  if (sPrimaryClock == 'on' || s2ndClock == 'on' || s3rdClock == 'on' || s4thClock == 'on' || sDate == 'on' || sTabTitle == 'tab-time' || sTabTitle == 'tab-timedate' || sTabTitle == 'tab-datetime' || sTabTitle == 'tab-date') {
+  if (sPrimaryClock == "on" || s2ndClock == "on" || s3rdClock == "on" || s4thClock == "on" || sDate == "on" || sTabTitle == "tab-time" || sTabTitle == "tab-timedate" || sTabTitle == "tab-datetime" || sTabTitle == "tab-date") {
     updateAll();
   }
 

--- a/src/js/run.js
+++ b/src/js/run.js
@@ -4,69 +4,69 @@
 function updateAll() {
   var dt = new Date();
   var timeDiv = $("#time");
-  var hourDiv = timeDiv.find('.hour');
-  var minuteDiv = timeDiv.find('.minute');
-  var secondDiv = timeDiv.find('.second');
-  var meridiemDiv = timeDiv.find('.meridiem');
-  var delimiterDiv = timeDiv.find('.delimiter');
-  var timeOutput = '';
-  var dateOutput = '';
+  var hourDiv = timeDiv.find(".hour");
+  var minuteDiv = timeDiv.find(".minute");
+  var secondDiv = timeDiv.find(".second");
+  var meridiemDiv = timeDiv.find(".meridiem");
+  var delimiterDiv = timeDiv.find(".delimiter");
+  var timeOutput = "";
+  var dateOutput = "";
 
   // Time
   if (
-    (sPrimaryClock == 'on') ||
-    (sPrimaryClock == 'off' && sTabTitle == 'tab-time') ||
-    (sPrimaryClock == 'off' && sTabTitle == 'tab-timedate') ||
-    (sPrimaryClock == 'off' && sTabTitle == 'tab-datetime')
+    (sPrimaryClock == "on") ||
+    (sPrimaryClock == "off" && sTabTitle == "tab-time") ||
+    (sPrimaryClock == "off" && sTabTitle == "tab-timedate") ||
+    (sPrimaryClock == "off" && sTabTitle == "tab-datetime")
   ) {
     if (sPrimaryClockTimezone == "" || sPrimaryClockTimezone == null) {
       sPrimaryClockTimezone = moment.tz.guess();
     }
-    if (sAnalog == 'on') {
+    if (sAnalog == "on") {
       var analogNow = moment().tz(sPrimaryClockTimezone),
         analogSecond = analogNow.seconds() * 6,
         analogMinute = analogNow.minutes() * 6 + analogSecond / 60,
         analogHour = ((analogNow.hours() % 12) / 12) * 360 + analogMinute / 12;
-      $('#analog-hour').css("transform", "rotateZ(" + analogHour + "deg)");
-      $('#analog-minute').css("transform", "rotateZ(" + analogMinute + "deg)");
-      $('#analog-second').css("transform", "rotateZ(" + analogSecond + "deg)");
+      $("#analog-hour").css("transform", "rotateZ(" + analogHour + "deg)");
+      $("#analog-minute").css("transform", "rotateZ(" + analogMinute + "deg)");
+      $("#analog-second").css("transform", "rotateZ(" + analogSecond + "deg)");
       if (sMilitary == "on") {
-        timeOutput = moment().tz(sPrimaryClockTimezone).format('H:mm');
+        timeOutput = moment().tz(sPrimaryClockTimezone).format("H:mm");
         if (sSeconds == "on") {
-          timeOutput = moment().tz(sPrimaryClockTimezone).format('H:mm:ss');
+          timeOutput = moment().tz(sPrimaryClockTimezone).format("H:mm:ss");
         }
       } else {
-        timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm');
+        timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm");
         if (sSeconds == "on") {
-          timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm:ss');
+          timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm:ss");
         }
         if (sMeridiem == "on") {
-          timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm a');
+          timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm a");
           if (sSeconds == "on") {
-            timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm:ss a');
+            timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm:ss a");
           }
         }
       }
     } else {
       if (sMilitary == "on") {
-        timeOutput = moment().tz(sPrimaryClockTimezone).format('H:mm');
-        timeDiv.attr('datetime', moment().tz(sPrimaryClockTimezone).format('HH:mm:ss'));
-        hourDiv.text(moment().tz(sPrimaryClockTimezone).format('H'));
+        timeOutput = moment().tz(sPrimaryClockTimezone).format("H:mm");
+        timeDiv.attr("datetime", moment().tz(sPrimaryClockTimezone).format("HH:mm:ss"));
+        hourDiv.text(moment().tz(sPrimaryClockTimezone).format("H"));
         if (sSeconds == "on") {
-          timeOutput = moment().tz(sPrimaryClockTimezone).format('H:mm:ss');
+          timeOutput = moment().tz(sPrimaryClockTimezone).format("H:mm:ss");
         }
       } else {
-        timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm');
-        timeDiv.attr('datetime', moment().tz(sPrimaryClockTimezone).format('hh:mm:ss'));
-        hourDiv.text(moment().tz(sPrimaryClockTimezone).format('h'));
+        timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm");
+        timeDiv.attr("datetime", moment().tz(sPrimaryClockTimezone).format("hh:mm:ss"));
+        hourDiv.text(moment().tz(sPrimaryClockTimezone).format("h"));
         if (sSeconds == "on") {
-          timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm:ss');
+          timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm:ss");
         }
         if (sMeridiem == "on") {
-          timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm a');
-          meridiemDiv.text(moment().tz(sPrimaryClockTimezone).format('a'));
+          timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm a");
+          meridiemDiv.text(moment().tz(sPrimaryClockTimezone).format("a"));
           if (sSeconds == "on") {
-            timeOutput = moment().tz(sPrimaryClockTimezone).format('h:mm:ss a');
+            timeOutput = moment().tz(sPrimaryClockTimezone).format("h:mm:ss a");
           }
         }
       }
@@ -78,7 +78,7 @@ function updateAll() {
           $this.append("<span>" + el + "</span");
         });
       });
-      minuteDiv.text(moment().tz(sPrimaryClockTimezone).format('mm'));
+      minuteDiv.text(moment().tz(sPrimaryClockTimezone).format("mm"));
       minuteDiv.each(function(index) {
         var characters = $(this).text().split("");
         $this = $(this);
@@ -88,7 +88,7 @@ function updateAll() {
         });
       });
       if (sSeconds == "on") {
-        secondDiv.text(moment().tz(sPrimaryClockTimezone).format('ss'));
+        secondDiv.text(moment().tz(sPrimaryClockTimezone).format("ss"));
         secondDiv.each(function(index) {
           var characters = $(this).text().split("");
           $this = $(this);
@@ -102,11 +102,11 @@ function updateAll() {
       if (sDelimiter == "on" && sBlinking == "on") {
         if (dt.getMilliseconds() < 500) {
           delimiterDiv.css({
-            'opacity': '1'
+            "opacity": "1"
           });
         } else {
           delimiterDiv.css({
-            'opacity': '0.5'
+            "opacity": "0.5"
           });
         }
       }
@@ -114,62 +114,62 @@ function updateAll() {
   }
 
   // Additional Clocks
-  if (s2ndClock == 'on') {
+  if (s2ndClock == "on") {
     var clock2Div = $("#display-clock2-time");
     if (s2ndClockTimezone == "" || s2ndClockTimezone == null) {
       s2ndClockTimezone = moment.tz.guess();
     }
     if (sMilitary == "on") {
-      clock2Div.find('.hour').text(moment().tz(s2ndClockTimezone).format('H'));
-      clock2Div.find('.minute').text(moment().tz(s2ndClockTimezone).format('mm'));
-      clock2Div.find('time').attr('datetime', moment().tz(s2ndClockTimezone).format('H:mm'));
+      clock2Div.find(".hour").text(moment().tz(s2ndClockTimezone).format("H"));
+      clock2Div.find(".minute").text(moment().tz(s2ndClockTimezone).format("mm"));
+      clock2Div.find("time").attr("datetime", moment().tz(s2ndClockTimezone).format("H:mm"));
     } else {
-      clock2Div.find('.hour').text(moment().tz(s2ndClockTimezone).format('h'));
-      clock2Div.find('.minute').text(moment().tz(s2ndClockTimezone).format('mm'));
-      clock2Div.find('.meridiem').text(moment().tz(s2ndClockTimezone).format('a'));
-      clock2Div.find('time').attr('datetime', moment().tz(s2ndClockTimezone).format('h:mm'));
+      clock2Div.find(".hour").text(moment().tz(s2ndClockTimezone).format("h"));
+      clock2Div.find(".minute").text(moment().tz(s2ndClockTimezone).format("mm"));
+      clock2Div.find(".meridiem").text(moment().tz(s2ndClockTimezone).format("a"));
+      clock2Div.find("time").attr("datetime", moment().tz(s2ndClockTimezone).format("h:mm"));
     }
   }
-  if (s3rdClock == 'on') {
+  if (s3rdClock == "on") {
     var clock3Div = $("#display-clock3-time");
     if (s3rdClockTimezone == "" || s3rdClockTimezone == null) {
       s3rdClockTimezone = moment.tz.guess();
     }
     if (sMilitary == "on") {
-      clock3Div.find('.hour').text(moment().tz(s3rdClockTimezone).format('H'));
-      clock3Div.find('.minute').text(moment().tz(s3rdClockTimezone).format('mm'));
-      clock3Div.find('time').attr('datetime', moment().tz(s3rdClockTimezone).format('H:mm'));
+      clock3Div.find(".hour").text(moment().tz(s3rdClockTimezone).format("H"));
+      clock3Div.find(".minute").text(moment().tz(s3rdClockTimezone).format("mm"));
+      clock3Div.find("time").attr("datetime", moment().tz(s3rdClockTimezone).format("H:mm"));
     } else {
-      clock3Div.find('.hour').text(moment().tz(s3rdClockTimezone).format('h'));
-      clock3Div.find('.minute').text(moment().tz(s3rdClockTimezone).format('mm'));
-      clock3Div.find('.meridiem').text(moment().tz(s3rdClockTimezone).format('a'));
-      clock3Div.find('time').attr('datetime', moment().tz(s3rdClockTimezone).format('h:mm'));
+      clock3Div.find(".hour").text(moment().tz(s3rdClockTimezone).format("h"));
+      clock3Div.find(".minute").text(moment().tz(s3rdClockTimezone).format("mm"));
+      clock3Div.find(".meridiem").text(moment().tz(s3rdClockTimezone).format("a"));
+      clock3Div.find("time").attr("datetime", moment().tz(s3rdClockTimezone).format("h:mm"));
     }
   }
-  if (s4thClock == 'on') {
+  if (s4thClock == "on") {
     var clock4Div = $("#display-clock4-time");
     if (s4thClockTimezone == "" || s4thClockTimezone == null) {
       s4thClockTimezone = moment.tz.guess();
     }
     if (sMilitary == "on") {
-      clock4Div.find('.hour').text(moment().tz(s4thClockTimezone).format('H'));
-      clock4Div.find('.minute').text(moment().tz(s4thClockTimezone).format('mm'));
-      clock4Div.find('time').attr('datetime', moment().tz(s4thClockTimezone).format('H:mm'));
+      clock4Div.find(".hour").text(moment().tz(s4thClockTimezone).format("H"));
+      clock4Div.find(".minute").text(moment().tz(s4thClockTimezone).format("mm"));
+      clock4Div.find("time").attr("datetime", moment().tz(s4thClockTimezone).format("H:mm"));
     } else {
-      clock4Div.find('.hour').text(moment().tz(s4thClockTimezone).format('h'));
-      clock4Div.find('.minute').text(moment().tz(s4thClockTimezone).format('mm'));
-      clock4Div.find('.meridiem').text(moment().tz(s4thClockTimezone).format('a'));
-      clock4Div.find('time').attr('datetime', moment().tz(s4thClockTimezone).format('h:mm'));
+      clock4Div.find(".hour").text(moment().tz(s4thClockTimezone).format("h"));
+      clock4Div.find(".minute").text(moment().tz(s4thClockTimezone).format("mm"));
+      clock4Div.find(".meridiem").text(moment().tz(s4thClockTimezone).format("a"));
+      clock4Div.find("time").attr("datetime", moment().tz(s4thClockTimezone).format("h:mm"));
     }
   }
 
   // Date
 
   if (
-    (sDate == 'on') ||
-    (sDate == 'off' && sTabTitle == 'tab-date') ||
-    (sDate == 'off' && sTabTitle == 'tab-timedate') ||
-    (sDate == 'off' && sTabTitle == 'tab-datetime')
+    (sDate == "on") ||
+    (sDate == "off" && sTabTitle == "tab-date") ||
+    (sDate == "off" && sTabTitle == "tab-timedate") ||
+    (sDate == "off" && sTabTitle == "tab-datetime")
   ) {
     months = [
       chrome.i18n.getMessage("january"), 
@@ -201,276 +201,276 @@ function updateAll() {
     shortMonth = ("0" + (dt.getMonth() + 1)).slice(-2); // Returns a double digit month (01 vs 1)
     date = dt.getDate();
     shortDate = ("0" + dt.getDate()).slice(-2); // Returns a double digit date (01 vs 1)
-    $('#date time').attr('datetime', year + '-' + shortMonth + '-' + shortDate);
-    if (sDateFormat == 'little') {
-      if (sShortDate == 'on') {
-        if (sDay == 'on') {
-          if (sDateDelimiter == 'period') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortDate + '.' + shortMonth + '.' + shortYear;
-              $('#date time').html(dateOutput);
+    $("#date time").attr("datetime", year + "-" + shortMonth + "-" + shortDate);
+    if (sDateFormat == "little") {
+      if (sShortDate == "on") {
+        if (sDay == "on") {
+          if (sDateDelimiter == "period") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortDate + "." + shortMonth + "." + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortDate + '.' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortDate + "." + shortMonth;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'dash') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortDate + '-' + shortMonth + '-' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "dash") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortDate + "-" + shortMonth + "-" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortDate + '-' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortDate + "-" + shortMonth;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'space') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortDate + ' ' + shortMonth + ' ' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "space") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortDate + " " + shortMonth + " " + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortDate + ' ' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortDate + " " + shortMonth;
+              $("#date time").html(dateOutput);
             }
           } else {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortDate + '/' + shortMonth + '/' + shortYear;
-              $('#date time').html(dateOutput);
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortDate + "/" + shortMonth + "/" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortDate + '/' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortDate + "/" + shortMonth;
+              $("#date time").html(dateOutput);
             }
           }
         } else {
-          if (sDateDelimiter == 'period') {
-            if (sYear == 'on') {
-              dateOutput = shortDate + '.' + shortMonth + '.' + shortYear;
-              $('#date time').html(dateOutput);
+          if (sDateDelimiter == "period") {
+            if (sYear == "on") {
+              dateOutput = shortDate + "." + shortMonth + "." + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortDate + '.' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = shortDate + "." + shortMonth;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'dash') {
-            if (sYear == 'on') {
-              dateOutput = shortDate + '-' + shortMonth + '-' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "dash") {
+            if (sYear == "on") {
+              dateOutput = shortDate + "-" + shortMonth + "-" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortDate + '-' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = shortDate + "-" + shortMonth;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'space') {
-            if (sYear == 'on') {
-              dateOutput = shortDate + ' ' + shortMonth + ' ' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "space") {
+            if (sYear == "on") {
+              dateOutput = shortDate + " " + shortMonth + " " + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortDate + ' ' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = shortDate + " " + shortMonth;
+              $("#date time").html(dateOutput);
             }
           } else {
-            if (sYear == 'on') {
-              dateOutput = shortDate + '/' + shortMonth + '/' + shortYear;
-              $('#date time').html(dateOutput);
+            if (sYear == "on") {
+              dateOutput = shortDate + "/" + shortMonth + "/" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortDate + '/' + shortMonth;
-              $('#date time').html(dateOutput);
+              dateOutput = shortDate + "/" + shortMonth;
+              $("#date time").html(dateOutput);
             }
           }
         }
       } else {
-        if (sDay == 'on' && sYear == 'on') {
-          dateOutput = day + ', ' + date + ' ' + month + ' ' + year;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'off' && sYear == 'on') {
-          dateOutput = date + ' ' + month + ' ' + year;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'on' && sYear == 'off') {
-          dateOutput = day + ', ' + date + ' ' + month;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'off' && sYear == 'off') {
-          dateOutput = date + '&nbsp;' + month;
-          $('#date time').html(dateOutput);
+        if (sDay == "on" && sYear == "on") {
+          dateOutput = day + ", " + date + " " + month + " " + year;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "off" && sYear == "on") {
+          dateOutput = date + " " + month + " " + year;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "on" && sYear == "off") {
+          dateOutput = day + ", " + date + " " + month;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "off" && sYear == "off") {
+          dateOutput = date + "&nbsp;" + month;
+          $("#date time").html(dateOutput);
         }
       }
-    } else if (sDateFormat == 'big') {
-      if (sShortDate == 'on') {
-        if (sDay == 'on') {
-          if (sDateDelimiter == 'period') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortYear + '.' + shortMonth + '.' + shortDate;
-              $('#date time').html(dateOutput);
+    } else if (sDateFormat == "big") {
+      if (sShortDate == "on") {
+        if (sDay == "on") {
+          if (sDateDelimiter == "period") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortYear + "." + shortMonth + "." + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + '.' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + "." + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'dash') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortYear + '-' + shortMonth + '-' + shortDate;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "dash") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortYear + "-" + shortMonth + "-" + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + '-' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + "-" + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'space') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortYear + ' ' + shortMonth + ' ' + shortDate;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "space") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortYear + " " + shortMonth + " " + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + ' ' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + " " + shortDate;
+              $("#date time").html(dateOutput);
             }
           } else {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortYear + '/' + shortMonth + '/' + shortDate;
-              $('#date time').html(dateOutput);
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortYear + "/" + shortMonth + "/" + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + '/' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + "/" + shortDate;
+              $("#date time").html(dateOutput);
             }
           }
         } else {
-          if (sDateDelimiter == 'period') {
-            if (sYear == 'on') {
-              dateOutput = shortYear + '.' + shortMonth + '.' + shortDate;
-              $('#date time').html(dateOutput);
+          if (sDateDelimiter == "period") {
+            if (sYear == "on") {
+              dateOutput = shortYear + "." + shortMonth + "." + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + '.' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + "." + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'dash') {
-            if (sYear == 'on') {
-              dateOutput = shortYear + '-' + shortMonth + '-' + shortDate;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "dash") {
+            if (sYear == "on") {
+              dateOutput = shortYear + "-" + shortMonth + "-" + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + '-' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + "-" + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'space') {
-            if (sYear == 'on') {
-              dateOutput = shortYear + ' ' + shortMonth + ' ' + shortDate;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "space") {
+            if (sYear == "on") {
+              dateOutput = shortYear + " " + shortMonth + " " + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + ' ' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + " " + shortDate;
+              $("#date time").html(dateOutput);
             }
           } else {
-            if (sYear == 'on') {
-              dateOutput = shortYear + '/' + shortMonth + '/' + shortDate;
-              $('#date time').html(dateOutput);
+            if (sYear == "on") {
+              dateOutput = shortYear + "/" + shortMonth + "/" + shortDate;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + '/' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + "/" + shortDate;
+              $("#date time").html(dateOutput);
             }
           }
         }
       } else {
-        if (sDay == 'on' && sYear == 'on') {
-          dateOutput = day + ', ' + year + ' ' + month + ' ' + date;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'off' && sYear == 'on') {
-          dateOutput = year + ' ' + month + ' ' + date;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'on' && sYear == 'off') {
-          dateOutput = day + ', ' + month + ' ' + date;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'off' && sYear == 'off') {
-          dateOutput = month + ' ' + date;
-          $('#date time').html(dateOutput);
+        if (sDay == "on" && sYear == "on") {
+          dateOutput = day + ", " + year + " " + month + " " + date;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "off" && sYear == "on") {
+          dateOutput = year + " " + month + " " + date;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "on" && sYear == "off") {
+          dateOutput = day + ", " + month + " " + date;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "off" && sYear == "off") {
+          dateOutput = month + " " + date;
+          $("#date time").html(dateOutput);
         }
       }
     } else {
-      if (sShortDate == 'on') {
-        if (sDay == 'on') {
-          if (sDateDelimiter == 'period') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortMonth + '.' + shortDate + '.' + shortYear;
-              $('#date time').html(dateOutput);
+      if (sShortDate == "on") {
+        if (sDay == "on") {
+          if (sDateDelimiter == "period") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortMonth + "." + shortDate + "." + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + '.' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + "." + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'dash') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortMonth + '-' + shortDate + '-' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "dash") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortMonth + "-" + shortDate + "-" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + '-' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + "-" + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'space') {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortMonth + ' ' + shortDate + ' ' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "space") {
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortMonth + " " + shortDate + " " + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + ' ' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + " " + shortDate;
+              $("#date time").html(dateOutput);
             }
           } else {
-            if (sYear == 'on') {
-              dateOutput = day + ', ' + shortMonth + '/' + shortDate + '/' + shortYear;
-              $('#date time').html(dateOutput);
+            if (sYear == "on") {
+              dateOutput = day + ", " + shortMonth + "/" + shortDate + "/" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = day + ', ' + shortMonth + '/' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = day + ", " + shortMonth + "/" + shortDate;
+              $("#date time").html(dateOutput);
             }
           }
         } else {
-          if (sDateDelimiter == 'period') {
-            if (sYear == 'on') {
-              dateOutput = shortMonth + '.' + shortDate + '.' + shortYear;
-              $('#date time').html(dateOutput);
+          if (sDateDelimiter == "period") {
+            if (sYear == "on") {
+              dateOutput = shortMonth + "." + shortDate + "." + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + '.' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + "." + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'dash') {
-            if (sYear == 'on') {
-              dateOutput = shortMonth + '-' + shortDate + '-' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "dash") {
+            if (sYear == "on") {
+              dateOutput = shortMonth + "-" + shortDate + "-" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + '-' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + "-" + shortDate;
+              $("#date time").html(dateOutput);
             }
-          } else if (sDateDelimiter == 'space') {
-            if (sYear == 'on') {
-              dateOutput = shortMonth + ' ' + shortDate + ' ' + shortYear;
-              $('#date time').html(dateOutput);
+          } else if (sDateDelimiter == "space") {
+            if (sYear == "on") {
+              dateOutput = shortMonth + " " + shortDate + " " + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + ' ' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + " " + shortDate;
+              $("#date time").html(dateOutput);
             }
           } else {
-            if (sYear == 'on') {
-              dateOutput = shortMonth + '/' + shortDate + '/' + shortYear;
-              $('#date time').html(dateOutput);
+            if (sYear == "on") {
+              dateOutput = shortMonth + "/" + shortDate + "/" + shortYear;
+              $("#date time").html(dateOutput);
             } else {
-              dateOutput = shortMonth + '/' + shortDate;
-              $('#date time').html(dateOutput);
+              dateOutput = shortMonth + "/" + shortDate;
+              $("#date time").html(dateOutput);
             }
           }
         }
       } else {
-        if (sDay == 'on' && sYear == 'on') {
-          dateOutput = day + ', ' + month + ' ' + date + ', ' + year;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'off' && sYear == 'on') {
-          dateOutput = month + ' ' + date + ', ' + year;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'on' && sYear == 'off') {
-          dateOutput = day + ', ' + month + ' ' + date;
-          $('#date time').html(dateOutput);
-        } else if (sDay == 'off' && sYear == 'off') {
-          dateOutput = month + ' ' + date;
-          $('#date time').html(dateOutput);
+        if (sDay == "on" && sYear == "on") {
+          dateOutput = day + ", " + month + " " + date + ", " + year;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "off" && sYear == "on") {
+          dateOutput = month + " " + date + ", " + year;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "on" && sYear == "off") {
+          dateOutput = day + ", " + month + " " + date;
+          $("#date time").html(dateOutput);
+        } else if (sDay == "off" && sYear == "off") {
+          dateOutput = month + " " + date;
+          $("#date time").html(dateOutput);
         }
       }
     }
-    if (sWeek == 'on') {
+    if (sWeek == "on") {
       var weekNum = moment().tz(sPrimaryClockTimezone).isoWeek();
-      if (sWeekLabel == 'wk') {
-        $('#date .week').html('Wk. ' + weekNum);
-      } else if (sWeekLabel == 'pound') {
-        $('#date .week').html('#' + weekNum);
-      } else if (sWeekLabel == 'none') {
-        $('#date .week').html('' + weekNum);
+      if (sWeekLabel == "wk") {
+        $("#date .week").html("Wk. " + weekNum);
+      } else if (sWeekLabel == "pound") {
+        $("#date .week").html("#" + weekNum);
+      } else if (sWeekLabel == "none") {
+        $("#date .week").html("" + weekNum);
       } else {
-        $('#date .week').html('Week ' + weekNum);
+        $("#date .week").html("Week " + weekNum);
       }
     }
   }
@@ -481,9 +481,9 @@ function updateAll() {
   } else if (sTabTitle == "tab-date") {
     document.title = dateOutput;
   } else if (sTabTitle == "tab-timedate") {
-    document.title = timeOutput + ' - ' + dateOutput;
+    document.title = timeOutput + " - " + dateOutput;
   } else if (sTabTitle == "tab-datetime") {
-    document.title = dateOutput + ' - ' + timeOutput;
+    document.title = dateOutput + " - " + timeOutput;
   } else if (sTabTitle == "new-tab") {
     document.title = "New Tab";
   } else if (sTabTitle == "tab-custom") {
@@ -491,10 +491,10 @@ function updateAll() {
   }
 
   // Set timeout
-  if (sPrimaryClock == 'on' || s2ndClock == 'on' || s3rdClock == 'on' || s4thClock == 'on' || sTabTitle == 'tab-time' || sTabTitle == 'tab-timedate' || sTabTitle == 'tab-datetime') {
+  if (sPrimaryClock == "on" || s2ndClock == "on" || s3rdClock == "on" || s4thClock == "on" || sTabTitle == "tab-time" || sTabTitle == "tab-timedate" || sTabTitle == "tab-datetime") {
     clearTimeout(updateAllTimer);
     updateAllTimer = setTimeout(updateAll, 500);
-  } else if (sDate == 'on' || sTabTitle == 'tab-date') {
+  } else if (sDate == "on" || sTabTitle == "tab-date") {
     clearTimeout(updateAllTimer);
     updateAllTimer = setTimeout(updateAll, 60000);
   } else {

--- a/src/js/set_default.js
+++ b/src/js/set_default.js
@@ -4,48 +4,48 @@
 
 function setVars() {
   updateAllTimer = null;
-  sPrimaryClock = 'on';
-  sSeconds = 'on';
-  sDimSeconds = 'off';
-  sDimDelimiter = 'on';
-  sMeridiem = 'on';
-  sMilitary = 'off';
-  sDelimiter = 'on';
-  sBlinking = 'off';
+  sPrimaryClock = "on";
+  sSeconds = "on";
+  sDimSeconds = "off";
+  sDimDelimiter = "on";
+  sMeridiem = "on";
+  sMilitary = "off";
+  sDelimiter = "on";
+  sBlinking = "off";
   sPrimaryClockTimezone = moment.tz.guess();
-  s2ndClock = 'off';
+  s2ndClock = "off";
   s2ndClockTimezone = moment.tz.guess();
-  s2ndClockLabel = '';
-  s3rdClock = 'off';
+  s2ndClockLabel = "";
+  s3rdClock = "off";
   s3rdClockTimezone = moment.tz.guess();
-  s3rdClockLabel = '';
-  s4thClock = 'off';
+  s3rdClockLabel = "";
+  s4thClock = "off";
   s4thClockTimezone = moment.tz.guess();
-  s4thClockLabel = '';
-  sDate = 'on';
-  sDay = 'on';
-  sYear = 'on';
-  sShortDate = 'off';
-  sDateFormat = 'middle';
-  sWeek = 'off';
-  sBackground = '#FFFFFF';
-  sForeground = '#000000';
-  sTabTitle = 'tab-time';
-  sTabTitleCustomMessage = 'Welcome to the World Wide Web!';
-  sCustomMessage = 'off';
-  sCustomMessageText = 'Welcome to the World Wide Web!';
-  sSearch = 'on';
-  sEngine = 'google';
-  sAnimation = 'on';
-  sScale = '75';
-  sBrackets = 'on';
-  sDimBrackets = 'on';
-  sBracketStyle = 'curly';
-  sDateDelimiter = 'slash';
-  sWeekLabel = 'week';
-  sFont = 'exo-2';
-  sHideSettingsToggle = 'off';
-  sAnalog = 'off';
+  s4thClockLabel = "";
+  sDate = "on";
+  sDay = "on";
+  sYear = "on";
+  sShortDate = "off";
+  sDateFormat = "middle";
+  sWeek = "off";
+  sBackground = "#FFFFFF";
+  sForeground = "#000000";
+  sTabTitle = "tab-time";
+  sTabTitleCustomMessage = "Welcome to the World Wide Web!";
+  sCustomMessage = "off";
+  sCustomMessageText = "Welcome to the World Wide Web!";
+  sSearch = "on";
+  sEngine = "google";
+  sAnimation = "on";
+  sScale = "75";
+  sBrackets = "on";
+  sDimBrackets = "on";
+  sBracketStyle = "curly";
+  sDateDelimiter = "slash";
+  sWeekLabel = "week";
+  sFont = "exo-2";
+  sHideSettingsToggle = "off";
+  sAnalog = "off";
 }
 
 function setDefaults(caretTabStatus, sLoad, loaded) {
@@ -57,14 +57,14 @@ function setDefaults(caretTabStatus, sLoad, loaded) {
     }
   });
   chrome.storage.sync.set({
-    'caretTabStatus': caretTabStatus
+    "caretTabStatus": caretTabStatus
   }, function() {
     if (!chrome.runtime.lastError) {
       console.log("^CaretTab - SAVED caretTabStatus: " + caretTabStatus);
     }
   });
   chrome.storage.sync.set({
-    'sLoad': '1.2.0'
+    "sLoad": "1.2.0"
   }, function() {
     if (!chrome.runtime.lastError) {
       console.log("^CaretTab - SAVED sLoad: 1.2.0");

--- a/src/js/update.js
+++ b/src/js/update.js
@@ -1,16 +1,16 @@
 // Check whether new version is installed
-if(typeof chrome.runtime.onInstalled  !== 'undefined')
+if(typeof chrome.runtime.onInstalled  !== "undefined")
 {
-    chrome.runtime.onInstalled.addListener(function (details)
-    {
-        if(details.reason == "install"){
-            chrome.storage.sync.set({'caretTabStatus':"installed"}, function() { if (!chrome.runtime.lastError) { console.log("saved caretTabStatus: installed"); }});
-        }else if(details.reason == "update"){
-            chrome.storage.sync.set({'caretTabStatus':"updated"}, function() { if (!chrome.runtime.lastError) { console.log("saved caretTabStatus: updated"); }});
-        }else{
-            chrome.storage.sync.set({'caretTabStatus':"existing"}, function() { if (!chrome.runtime.lastError) { console.log("saved caretTabStatus: existing"); }});
-        }
-    });
+  chrome.runtime.onInstalled.addListener(function (details)
+  {
+    if(details.reason == "install"){
+      chrome.storage.sync.set({"caretTabStatus":"installed"}, function() { if (!chrome.runtime.lastError) { console.log("saved caretTabStatus: installed"); }});
+    }else if(details.reason == "update"){
+      chrome.storage.sync.set({"caretTabStatus":"updated"}, function() { if (!chrome.runtime.lastError) { console.log("saved caretTabStatus: updated"); }});
+    }else{
+      chrome.storage.sync.set({"caretTabStatus":"existing"}, function() { if (!chrome.runtime.lastError) { console.log("saved caretTabStatus: existing"); }});
+    }
+  });
 }
 
-chrome.runtime.setUninstallURL('https://docs.google.com/forms/d/e/1FAIpQLSdGygInFzRggKclxz82yOaWKN4biHJTMXw-Vz-2rAnBhT5fqA/viewform');
+chrome.runtime.setUninstallURL("https://docs.google.com/forms/d/e/1FAIpQLSdGygInFzRggKclxz82yOaWKN4biHJTMXw-Vz-2rAnBhT5fqA/viewform");


### PR DESCRIPTION
* Enable necessary globals: jquery, webextensions, and moment
* Disable `console` use warnings since they are used throughout the codebase
* Run ESLint only on carettab code, not on vendor code unowned by this repo
* Autofix all auto-fixable warnings with `npm run-script lint -- --fix`