### PR TITLE
Changed link placeholder to encourage HTTPS

### DIFF
--- a/src/carettab.htm
+++ b/src/carettab.htm
@@ -640,7 +640,7 @@
                     <input id="s-link-label" type="text" placeholder="Label">
                 </div>
                 <div class="input input-text" style="width:35%">
-                    <input id="s-link-url" type="text" placeholder="http://">
+                    <input id="s-link-url" type="text" placeholder="https://">
                 </div>
                 <div class="label" style="flex: 0 0 auto;">
                     <button class="btn" id="s-link-add">&#10010;</button>


### PR DESCRIPTION
Change link placeholder from http:// to https:// to encourage HTTPS-Links. 

I can imagine that it would be a good idea to even pre-fill the textbox with "https://", instead of just setting the placeholder, so that users don't have to type it out everytime, but this seems like a profound change worthy of discussion in an issue first.