### PR TITLE
Script to found missing or unused i18n placeholders

### DIFF
--- a/checkI18nVars.js
+++ b/checkI18nVars.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+console.log("Awesome Command");
+const fs = require('fs');
+const { isObject } = require('util');
+
+
+function jsonReader(filePath, cb) {
+    fs.readFile(filePath, (err, fileData) => {
+        if (err) {
+            return cb && cb(err)
+        }
+        try {
+            const object = JSON.parse(fileData)
+            return cb && cb(null, object)
+        } catch (err) {
+            return cb && cb(err)
+        }
+    })
+} 
+
+function pushAndLog(key, val, arr) {
+    arr.push(key);
+    console.log(key + " : " + val);
+}
+
+jsonReader('src/assets/i18n/fr-FR.json', (err, i18nFile) => {
+    if (err) {
+        console.log(err)
+        return
+    }
+
+    // purée ca marche mais un bon codeur js va avoir une crise cardiaque en voyant ca ci dessous.
+
+    let arr= [];
+    for (let key of Object.keys(i18nFile)) {
+        if (isObject(i18nFile[key])) 
+        for (let key2 of Object.keys(i18nFile[key])) {
+            if (isObject(i18nFile[key][key2])) 
+            for (let key3 of Object.keys(i18nFile[key][key2])) {
+                if (isObject(i18nFile[key][key2][key3]))
+                for (let key4 of Object.keys(i18nFile[key][key2][key3])) {
+                    pushAndLog(key + "." + key2 + "." + key3 + "." + key4 , i18nFile[key][key2][key3][key4],arr);
+                }
+                else pushAndLog(key + "." + key2 + "." + key3 , i18nFile[key][key2][key3], arr);
+            }
+            else pushAndLog(key + "." + key2, i18nFile[key][key2], arr);
+            
+        }
+        else pushAndLog(key, i18nFile[key], arr)
+    }
+    console.log(arr);
+
+
+
+    
+})
+

--- a/checkI18nVars.sh
+++ b/checkI18nVars.sh
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# collect placeholder defined in i18n files, and search them in code.
+#
+
+beep=on
+verbose=off
+
+grep -E '\"(.*)?\": \"' src/assets/i18n/*.json  | cut -d '"' -f 2 | sort -u | while IFS= read -r ph
+do
+    pattern="\{\{.*\."$ph
+    
+    c=$(grep -r -E "$pattern" src/app | wc -l)
+
+    if [ "$verbose" = on ]; then  
+        printf "\n Word -> %s found %s in code \n" "$ph"  "$c"
+    fi
+
+    if [ "$c" -eq 0 ]; then
+        printf "\nPlaceholder --%s-- not found in code \n"  "$ph"
+        if [ "$beep" = on ]; then  printf "\a"; fi
+    else
+        if [ "$verbose" = on ]; then  printf "\nPlaceholder --%s-- found in %s files in code \n" "$ph" "${c}"; fi
+    fi
+
+    for f in src/assets/i18n/*.json; do
+        printf "-"
+        if n=$(grep -wic "$ph" "$f"); then
+            if [ "$verbose" = on ]; then  printf "\b\nfound %s in %s \n-" "${n}" "$f"; fi
+            if [ "$c" -eq 0 ]; then
+                printf "\b\n -- %s-- not found in code but found in %s \n-" "$ph" "$f"
+                if [ "$beep" = on ]; then  printf "\a"; fi
+            fi
+        else
+            if [ "$c" -ne 0 ]; then
+                  if [ "$beep" = on ]; then  printf "\a"; fi
+                printf "\b\n -- %s-- not found %s in %s \n-" "%ph" "${n}" "$f"
+            fi
+        fi
+        printf "\b"
+    done   
+done

--- a/checkI18nVars.sh
+++ b/checkI18nVars.sh
@@ -8,8 +8,17 @@ verbose=off
 
 grep -E '\"(.*)?\": \"' src/assets/i18n/*.json  | cut -d '"' -f 2 | sort -u | while IFS= read -r ph
 do
-    pattern="\{\{.*\."$ph
     
+    if [ "$verbose" = on ]; then  
+        printf "\n Word -> " "$ph"
+    fi
+
+    pattern="\{\{.*\."$ph"'"
+    
+    if [ "$verbose" = on ]; then  
+        printf "\b\ngrep -r -E \"%s\" src/app | wc -l\n-" "$pattern"
+    fi
+
     c=$(grep -r -E "$pattern" src/app | wc -l)
 
     if [ "$verbose" = on ]; then  
@@ -25,10 +34,13 @@ do
 
     for f in src/assets/i18n/*.json; do
         printf "-"
+   
+        if [ "$verbose" = on ]; then  printf "\b\n  grep -wic %s %s \n-" "$ph" "$f"; fi
+        
         if n=$(grep -wic "$ph" "$f"); then
             if [ "$verbose" = on ]; then  printf "\b\nfound %s in %s \n-" "${n}" "$f"; fi
             if [ "$c" -eq 0 ]; then
-                printf "\b\n -- %s-- not found in code but found in %s \n-" "$ph" "$f"
+               # printf "\b\n -- %s-- not found in code but found in %s \n-" "$ph" "$f"
                 if [ "$beep" = on ]; then  printf "\a"; fi
             fi
         else


### PR DESCRIPTION
see https://github.com/bluecaret/carettab/issues/252#issuecomment-963359341

Script to found missing or unused i18n placeholders
- V1. provide a list of placehoder found nowhere in code
- V2.  (later)  provide a list of placehoder found in code but missing in i18n files
- V3 use full path of place holder (not only final part)

Unfortunately write in bash not in js.

I would use it to solve #252   but I suppose that tool in bash is not welcome.

Option 1 : I keep it in a gist
Option 2 : I found help to rewrite it in js.



