### PR TITLE
Option to randomly cycle through preset themes 

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Submit a Pull Request in GitHub if you would like to contribute. Always welcome 
 ### First time installation:
 1. Make sure you have [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed 
 2. Run `npm install` for packages necessary to build the project
-3. Run `npm install web-ext` to be able to start a dev build instance in Chrome
 
 ### Development workflow:
 1. Run `npm start` for a dev build. This is where local changes will be compiled and built.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,18 @@ You can install CaretTab through the browser web stores
 Submit a Pull Request in GitHub if you would like to contribute. Always welcome help with translations especially :)
 
 ## Build
-Run `npm start` for a dev build. You can then run `npm run start:chrome` to start an instance of the dev build in Chrome.
+### First time installation:
+1. Make sure you have [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed 
+2. Run `npm install` for packages necessary to build the project
+3. Run `npm install web-ext` to be able to start a dev build instance in Chrome
 
-You can run in FireFox by running `npm run compile:firefox` followed by `npm run start:firefox`.
+### Development workflow:
+1. Run `npm start` for a dev build. This is where local changes will be compiled and built.
+2. Then, you can then run `npm run start:chrome` to start an instance of the dev build in Chrome. Alternatively, you can run in FireFox by running `npm run compile:firefox` followed by `npm run start:firefox`.
 
 ### For a production ready build
 
-Run `npm run compile:all` to build the project and package for all browsers. The build artifacts will be stored in the `artifacts/` directory.
+1. Run `npm run compile:all` to build the project and package for all browsers. The build artifacts will be stored in the `artifacts/` directory.
 
 ## Credit
 CaretTab was designed and developed by BlueCaret (John W Hancock)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "shx": "^0.3.3",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "web-ext":"^6.5.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -34,6 +34,7 @@ export class DesignSettings {
     public customFontWeight = 40,
     public background = '#ffffff',
     public foreground = '#000000',
+    public randTheme = false,
     public colorsId = 0,
     public patternId = 0,
     public imageSize = 10,

--- a/src/app/options/design/design.component.html
+++ b/src/app/options/design/design.component.html
@@ -44,7 +44,13 @@
   </div>
   <!-- Colors -->
   <h3>{{'options.design.colors' | translate}}</h3>
+  <!-- random preset theme toggle -->
   <div class="input">
+    <label for="randTheme">{{'options.design.randTheme' | translate}}</label>
+    <options-toggle id="randTheme" name="randTheme" [(ngModel)]="settings.config.design.randTheme" (ngModelChange)="ga.field('design.randTheme', settings.config.design.randTheme);"></options-toggle>
+  </div>
+  <!-- Custom color settings -->
+  <div class="input" *ngIf="!(settings.config.design.randTheme)">
     <label id="set-foreground-label" for="set-foreground">{{'options.design.fg' | translate}}</label>
     <div class="grid cols-3">
       <div class="span-1">
@@ -59,7 +65,7 @@
       </div>
     </div>
   </div>
-  <div class="input">
+  <div class="input" *ngIf="!(settings.config.design.randTheme)">
     <label id="set-background-label" for="set-background">{{'options.design.bg' | translate}}</label>
     <div class="grid cols-3">
       <div class="span-1">
@@ -76,14 +82,7 @@
       </div>
     </div>
   </div>
-
-  <!-- random preset theme toggle -->
-  <div class="input">
-    <label for="randTheme">{{'options.design.randTheme' | translate}}</label>
-    <options-toggle id="randTheme" name="randTheme" [(ngModel)]="settings.config.design.randTheme" (ngModelChange)="ga.field('design.randTheme', settings.config.design.randTheme);"></options-toggle>
-  </div>
-
-  <div id="themeBtns" class="grid cols-4 mt designGrid">
+  <div id="themeBtns" class="grid cols-4 mt designGrid" *ngIf="!(settings.config.design.randTheme)">
     <button
       *ngFor="let color of colors;"
       class="colorsBtn btn btnBlock"

--- a/src/app/options/design/design.component.html
+++ b/src/app/options/design/design.component.html
@@ -76,6 +76,13 @@
       </div>
     </div>
   </div>
+
+  <!-- random preset theme toggle -->
+  <div class="input">
+    <label for="randTheme">{{'options.design.randTheme' | translate}}</label>
+    <options-toggle id="randTheme" name="randTheme" [(ngModel)]="settings.config.design.randTheme" (ngModelChange)="ga.field('design.randTheme', settings.config.design.randTheme);"></options-toggle>
+  </div>
+
   <div id="themeBtns" class="grid cols-4 mt designGrid">
     <button
       *ngFor="let color of colors;"

--- a/src/app/tab/tab.component.ts
+++ b/src/app/tab/tab.component.ts
@@ -4,7 +4,7 @@ import { DomSanitizer } from '@angular/platform-browser';
 import { TranslateService } from '@ngx-translate/core';
 import { SharedService } from '../_shared/shared.service';
 import { Storage } from '../_storage/storage.service';
-import { span, bgSize, bgBlend, patterns } from '../_shared/lists/lists';
+import { span, colors, bgSize, bgBlend, patterns } from '../_shared/lists/lists';
 import { tab } from '../_shared/animations';
 
 @Component({
@@ -32,6 +32,15 @@ export class TabComponent implements OnInit, AfterViewInit {
   }
 
   ngOnInit() {
+
+    // pick a random theme
+    var c = colors[Math.floor(Math.random()*colors.length)];
+
+    this.settings.config.design.background = c.bg;
+    this.settings.config.design.foreground = c.fg;
+    this.settings.config.design.colorsId = c.id;
+
+    // rest of the initial init
     let localBgColor = this.settings.config.design.background;
     this.shared.bgColor = localBgColor;
     localStorage.setItem('ct-background', localBgColor);

--- a/src/app/tab/tab.component.ts
+++ b/src/app/tab/tab.component.ts
@@ -34,11 +34,13 @@ export class TabComponent implements OnInit, AfterViewInit {
   ngOnInit() {
 
     // pick a random theme
-    var c = colors[Math.floor(Math.random()*colors.length)];
+    if(this.settings.config.design.randTheme) {
+      var c = colors[Math.floor(Math.random()*colors.length)];
 
-    this.settings.config.design.background = c.bg;
-    this.settings.config.design.foreground = c.fg;
-    this.settings.config.design.colorsId = c.id;
+      this.settings.config.design.background = c.bg;
+      this.settings.config.design.foreground = c.fg;
+      this.settings.config.design.colorsId = c.id;
+    }
 
     // rest of the initial init
     let localBgColor = this.settings.config.design.background;

--- a/src/app/tab/tab.component.ts
+++ b/src/app/tab/tab.component.ts
@@ -42,7 +42,6 @@ export class TabComponent implements OnInit, AfterViewInit {
       this.settings.config.design.colorsId = c.id;
     }
 
-    // rest of the initial init
     let localBgColor = this.settings.config.design.background;
     this.shared.bgColor = localBgColor;
     localStorage.setItem('ct-background', localBgColor);

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -159,6 +159,7 @@
       "globalSize": "Global size",
       "globalSizeDesc": "Adjust the size of all elements.",
       "hardToSee": "Image too hard to see? Try changing the filter.",
+      "randTheme": "Random preset theme",
       "removeWallpaper": "Click to remove selected wallpaper",
       "selectedWallpaper": "Selected wallpaper",
       "wallpaper": "Wallpaper"


### PR DESCRIPTION
## What?
There is now a toggle option in the "design" panel of Options/Settings that gives the user a choice to have their foreground & background (collectively called "theme") be randomly selected. The selection comes from 1 of many preset themes to ensure contrast and readability, and it is done every time the new tab is loaded or refreshed. 

Fixes #225  

This PR also includes a small addition to the README on first time installation and building. 

## Why?
This is a requested enhancement feature and a currently open issue: [https://github.com/bluecaret/carettab/issues/225](https://github.com/bluecaret/carettab/issues/225)

## How?

- Whether or not to randomly select a theme is saved as a configuration under `DesignSettings` and can be referred to as `this.settings.config.design.randTheme` in code. 
- Upon loading the new tab, in `tab.components.ts`'s `ngOnInit()`, if `randTheme` is on (ie `True`), then it will randomly select a color from `lists.ts`'s list of colors (by generating an index within range of the list's length), and set the theme accordingly. 
- The frontend toggle button is simply added to `design.component.html`. 

## Testing?
- Successful local dev build 
- Manual testing through clicking and refreshing
- Successful production build and loaded the extension artifact into edge to ensure the same behavior

## Screenshots
Screenshot of the toggle option in "design" panel: 
![](https://files.slack.com/files-pri/T02E7E44761-F02NQM6AT4N/screenshot.png?pub_secret=ab792ae3dc)

## Anything Else?
- Translation is needed for the "Random preset theme" blurb that appears in the "design" panel