### PR TITLE
Option to display Julian date (ie. nth date of the year)

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,18 @@
+## What?
+Fixes # (issue)
+
+## Why?
+This is a requested feature / known bug / known issue / good to implement because blah.
+
+## How?
+Explain your code and any design decisions.
+
+## Testing?
+Please verify that you can at least peform a successful dev build and production build.
+
+## Screenshots (optional)
+
+## Anything Else?
+Any follow up changes needed? Technical debt? Optimization? etc. 
+
+<!-- Read more about pull requests: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/  -->

--- a/README.md
+++ b/README.md
@@ -48,7 +48,6 @@ Submit a Pull Request in GitHub if you would like to contribute. Always welcome 
 ### First time installation:
 1. Make sure you have [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed 
 2. Run `npm install` for packages necessary to build the project
-3. Run `npm install web-ext` to be able to start a dev build instance in Chrome
 
 ### Development workflow:
 1. Run `npm start` for a dev build. This is where local changes will be compiled and built.

--- a/README.md
+++ b/README.md
@@ -45,13 +45,18 @@ You can install CaretTab through the browser web stores
 Submit a Pull Request in GitHub if you would like to contribute. Always welcome help with translations especially :)
 
 ## Build
-Run `npm start` for a dev build. You can then run `npm run start:chrome` to start an instance of the dev build in Chrome.
+### First time installation:
+1. Make sure you have [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed 
+2. Run `npm install` for packages necessary to build the project
+3. Run `npm install web-ext` to be able to start a dev build instance in Chrome
 
-You can run in FireFox by running `npm run compile:firefox` followed by `npm run start:firefox`.
+### Development workflow:
+1. Run `npm start` for a dev build. This is where local changes will be compiled and built.
+2. Then, you can then run `npm run start:chrome` to start an instance of the dev build in Chrome. Alternatively, you can run in FireFox by running `npm run compile:firefox` followed by `npm run start:firefox`.
 
 ### For a production ready build
 
-Run `npm run compile:all` to build the project and package for all browsers. The build artifacts will be stored in the `artifacts/` directory.
+1. Run `npm run compile:all` to build the project and package for all browsers. The build artifacts will be stored in the `artifacts/` directory.
 
 ## Credit
 CaretTab was designed and developed by BlueCaret (John W Hancock)

--- a/package.json
+++ b/package.json
@@ -54,7 +54,8 @@
     "shx": "^0.3.3",
     "ts-node": "~4.1.0",
     "tslint": "~5.9.1",
-    "typescript": "3.5.3"
+    "typescript": "3.5.3",
+    "web-ext": "^6.5.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -234,8 +234,6 @@ export class DateSettings {
       abbr: false
     },
     public ordinalContent = {
-      scaling: 10,
-      offset: 0,
       delimiter: '/'
     },
     public julianDate = {
@@ -245,7 +243,9 @@ export class DateSettings {
     public week = {
       enabled: false,
       label: 'Week',
-      iso: false
+      iso: false,
+      scaling: 10, // controls ordinalContent as a whole
+      offset: 0, // controls ordinalContent as a whole
     },
   ) {}
 }

--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -233,6 +233,13 @@ export class DateSettings {
       enabled: true,
       abbr: false
     },
+    public dayOfYear = {
+      enabled: false,
+      label: "Day",
+      scaling: 10,
+      offset: 0,
+      iso: false
+    },
     public week = {
       enabled: false,
       label: 'Week',

--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -233,7 +233,7 @@ export class DateSettings {
       enabled: true,
       abbr: false
     },
-    public dayOfYear = {
+    public julianDate = {
       enabled: false,
       label: "Day",
       scaling: 10,

--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -236,6 +236,7 @@ export class DateSettings {
     public ordinalContent = {
       scaling: 10,
       offset: 0,
+      delimiter: '/'
     },
     public julianDate = {
       enabled: false,

--- a/src/app/_storage/settings.ts
+++ b/src/app/_storage/settings.ts
@@ -233,18 +233,17 @@ export class DateSettings {
       enabled: true,
       abbr: false
     },
+    public ordinalContent = {
+      scaling: 10,
+      offset: 0,
+    },
     public julianDate = {
       enabled: false,
       label: "Day",
-      scaling: 10,
-      offset: 0,
-      iso: false
     },
     public week = {
       enabled: false,
       label: 'Week',
-      scaling: 10,
-      offset: 0,
       iso: false
     },
   ) {}

--- a/src/app/options/date/date.component.html
+++ b/src/app/options/date/date.component.html
@@ -80,6 +80,8 @@
       <label>{{'options.date.abbr' | translate}}</label>
       <options-toggle name="dayOfWeekAbbr" [(ngModel)]="settings.config.date.dayOfWeek.abbr" (ngModelChange)="ga.field('date.dayOfWeek.abbr', settings.config.date.dayOfWeek.abbr);"></options-toggle>
     </div>
+
+    <!-- Ordinal Content settings -->
     <h3>{{'options.date.ordinalContent' | translate}}</h3>
     <div class="input">
       <label>{{'options.date.enableWeekNum' | translate}}</label>
@@ -96,6 +98,10 @@
     <div class="input" *ngIf="settings.config.date.julianDate.enabled">
       <label for="julianDateLabel">{{'options.date.julianDateLabel' | translate}}</label>
       <input type="text" id="julianDateLabel" name="julianDateLabel" [(ngModel)]="settings.config.date.julianDate.label" autocomplete="off" (change)="ga.field('date.julianDate.label', 'userData');">
+    </div>
+    <div class="input" *ngIf="settings.config.date.week.enabled && settings.config.date.julianDate.enabled">
+      <label for="ordinalContentDelimiter">{{'options.common.delimiter' | translate}}</label>
+      <input type="text" maxlength="1" id="orindalContentDelimiter" name="ordinalContentDelimiter" [(ngModel)]="settings.config.date.ordinalContent.delimiter" (change)="ga.field('date.ordinalContent.delimiter', settings.config.date.ordinalContent.delimiter);" autocomplete="off">
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled || settings.config.date.julianDate.enabled">
       <label>{{'options.common.size' | translate}}</label>

--- a/src/app/options/date/date.component.html
+++ b/src/app/options/date/date.component.html
@@ -105,11 +105,11 @@
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled || settings.config.date.julianDate.enabled">
       <label>{{'options.common.size' | translate}}</label>
-      <options-range name="ordinalContentSize" min="1" max="50" [(ngModel)]="settings.config.date.ordinalContent.scaling" (change)="ga.field('date.ordinalContent.scaling', settings.config.date.ordinalContent.scaling);"></options-range>
+      <options-range name="ordinalContentSize" min="1" max="50" [(ngModel)]="settings.config.date.week.scaling" (change)="ga.field('date.week.scaling', settings.config.date.week.scaling);"></options-range>
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled || settings.config.date.julianDate.enabled">
       <label>{{'options.common.offset' | translate}}</label>
-      <options-range name="ordinalContentOffset" min="-50" max="50" [(ngModel)]="settings.config.date.ordinalContent.offset" (change)="ga.field('date.ordinalContent.offset', settings.config.date.ordinalContent.offset);"></options-range>
+      <options-range name="ordinalContentOffset" min="-50" max="50" [(ngModel)]="settings.config.date.week.offset" (change)="ga.field('date.week.offset', settings.config.date.week.offset);"></options-range>
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled">
       <label>{{'options.date.weekIso' | translate}}<tooltip text="{{'options.date.weekIsoDesc' | translate}}"></tooltip></label>

--- a/src/app/options/date/date.component.html
+++ b/src/app/options/date/date.component.html
@@ -80,7 +80,7 @@
       <label>{{'options.date.abbr' | translate}}</label>
       <options-toggle name="dayOfWeekAbbr" [(ngModel)]="settings.config.date.dayOfWeek.abbr" (ngModelChange)="ga.field('date.dayOfWeek.abbr', settings.config.date.dayOfWeek.abbr);"></options-toggle>
     </div>
-    <h3>{{'options.date.weekNum' | translate}}</h3>
+    <h3>{{'options.date.ordinalContent' | translate}}</h3>
     <div class="input">
       <label>{{'options.date.enableWeekNum' | translate}}</label>
       <options-toggle type="toggle" name="week" [(ngModel)]="settings.config.date.week.enabled" (ngModelChange)="ga.field('date.week.enabled', settings.config.date.week.enabled);"></options-toggle>
@@ -90,16 +90,20 @@
       <options-toggle type="toggle" name="julianDate" [(ngModel)]="settings.config.date.julianDate.enabled" (ngModelChange)="ga.field('date.julianDate.enabled', settings.config.date.julianDate.enabled);"></options-toggle>
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled">
-      <label for="weekLabel">{{'options.common.label' | translate}}</label>
+      <label for="weekLabel">{{'options.date.weekNumLabel' | translate}}</label>
       <input type="text" id="weekLabel" name="weekLabel" [(ngModel)]="settings.config.date.week.label" autocomplete="off" (change)="ga.field('date.week.label', 'userData');">
     </div>
-    <div class="input" *ngIf="settings.config.date.week.enabled">
-      <label>{{'options.common.size' | translate}}</label>
-      <options-range name="weekSize" min="1" max="50" [(ngModel)]="settings.config.date.week.scaling" (change)="ga.field('date.week.scaling', settings.config.date.week.scaling);"></options-range>
+    <div class="input" *ngIf="settings.config.date.julianDate.enabled">
+      <label for="julianDateLabel">{{'options.date.julianDateLabel' | translate}}</label>
+      <input type="text" id="julianDateLabel" name="julianDateLabel" [(ngModel)]="settings.config.date.julianDate.label" autocomplete="off" (change)="ga.field('date.julianDate.label', 'userData');">
     </div>
-    <div class="input" *ngIf="settings.config.date.week.enabled">
+    <div class="input" *ngIf="settings.config.date.week.enabled || settings.config.date.julianDate.enabled">
+      <label>{{'options.common.size' | translate}}</label>
+      <options-range name="ordinalContentSize" min="1" max="50" [(ngModel)]="settings.config.date.ordinalContent.scaling" (change)="ga.field('date.ordinalContent.scaling', settings.config.date.ordinalContent.scaling);"></options-range>
+    </div>
+    <div class="input" *ngIf="settings.config.date.week.enabled || settings.config.date.julianDate.enabled">
       <label>{{'options.common.offset' | translate}}</label>
-      <options-range name="weekOffset" min="-50" max="50" [(ngModel)]="settings.config.date.week.offset" (change)="ga.field('date.week.offset', settings.config.date.week.offset);"></options-range>
+      <options-range name="ordinalContentOffset" min="-50" max="50" [(ngModel)]="settings.config.date.ordinalContent.offset" (change)="ga.field('date.ordinalContent.offset', settings.config.date.ordinalContent.offset);"></options-range>
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled">
       <label>{{'options.date.weekIso' | translate}}<tooltip text="{{'options.date.weekIsoDesc' | translate}}"></tooltip></label>

--- a/src/app/options/date/date.component.html
+++ b/src/app/options/date/date.component.html
@@ -85,6 +85,10 @@
       <label>{{'options.date.enableWeekNum' | translate}}</label>
       <options-toggle type="toggle" name="week" [(ngModel)]="settings.config.date.week.enabled" (ngModelChange)="ga.field('date.week.enabled', settings.config.date.week.enabled);"></options-toggle>
     </div>
+    <div class="input">
+      <label>{{'options.date.enableDayOfYear' | translate}}</label>
+      <options-toggle type="toggle" name="dayOfYear" [(ngModel)]="settings.config.date.dayOfYear.enabled" (ngModelChange)="ga.field('date.dayOfYear.enabled', settings.config.date.dayOfYear.enabled);"></options-toggle>
+    </div>
     <div class="input" *ngIf="settings.config.date.week.enabled">
       <label for="weekLabel">{{'options.common.label' | translate}}</label>
       <input type="text" id="weekLabel" name="weekLabel" [(ngModel)]="settings.config.date.week.label" autocomplete="off" (change)="ga.field('date.week.label', 'userData');">

--- a/src/app/options/date/date.component.html
+++ b/src/app/options/date/date.component.html
@@ -86,8 +86,8 @@
       <options-toggle type="toggle" name="week" [(ngModel)]="settings.config.date.week.enabled" (ngModelChange)="ga.field('date.week.enabled', settings.config.date.week.enabled);"></options-toggle>
     </div>
     <div class="input">
-      <label>{{'options.date.enableDayOfYear' | translate}}</label>
-      <options-toggle type="toggle" name="dayOfYear" [(ngModel)]="settings.config.date.dayOfYear.enabled" (ngModelChange)="ga.field('date.dayOfYear.enabled', settings.config.date.dayOfYear.enabled);"></options-toggle>
+      <label>{{'options.date.enableJulianDate' | translate}}</label>
+      <options-toggle type="toggle" name="julianDate" [(ngModel)]="settings.config.date.julianDate.enabled" (ngModelChange)="ga.field('date.julianDate.enabled', settings.config.date.julianDate.enabled);"></options-toggle>
     </div>
     <div class="input" *ngIf="settings.config.date.week.enabled">
       <label for="weekLabel">{{'options.common.label' | translate}}</label>

--- a/src/app/tab/date/date.component.html
+++ b/src/app/tab/date/date.component.html
@@ -13,5 +13,5 @@
   class="ordinalContent"
   [style.fontSize]="shared.getFontSize(settings.config.date.ordinalContent.scaling, 6)"
   [style.transform]="shared.getOffset(settings.config.date.ordinalContent.offset)">
-  <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.julianDate.enabled'> / </span><!--day of year--><span *ngIf='settings.config.date.julianDate.enabled'>{{settings.config.date.julianDate.label}} {{getJulianDate()}}</span>
+  <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.julianDate.enabled'> {{ getOrdinalContentDelimiter() }} </span><!--day of year--><span *ngIf='settings.config.date.julianDate.enabled'>{{settings.config.date.julianDate.label}} {{getJulianDate()}}</span>
 </div>

--- a/src/app/tab/date/date.component.html
+++ b/src/app/tab/date/date.component.html
@@ -11,7 +11,7 @@
 </div>
 <div
   class="ordinalContent"
-  [style.fontSize]="shared.getFontSize(settings.config.date.ordinalContent.scaling, 6)"
-  [style.transform]="shared.getOffset(settings.config.date.ordinalContent.offset)">
+  [style.fontSize]="shared.getFontSize(settings.config.date.week.scaling, 6)"
+  [style.transform]="shared.getOffset(settings.config.date.week.offset)">
   <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.julianDate.enabled'> {{ getOrdinalContentDelimiter() }} </span><!--day of year--><span *ngIf='settings.config.date.julianDate.enabled'>{{settings.config.date.julianDate.label}} {{getJulianDate()}}</span>
 </div>

--- a/src/app/tab/date/date.component.html
+++ b/src/app/tab/date/date.component.html
@@ -11,7 +11,7 @@
 </div>
 <div
   class="ordinalContent"
-  [style.fontSize]="shared.getFontSize(settings.config.date.week.scaling, 6)"
-  [style.transform]="shared.getOffset(settings.config.date.week.offset)">
+  [style.fontSize]="shared.getFontSize(settings.config.date.ordinalContent.scaling, 6)"
+  [style.transform]="shared.getOffset(settings.config.date.ordinalContent.offset)">
   <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.julianDate.enabled'> / </span><!--day of year--><span *ngIf='settings.config.date.julianDate.enabled'>{{settings.config.date.julianDate.label}} {{getJulianDate()}}</span>
 </div>

--- a/src/app/tab/date/date.component.html
+++ b/src/app/tab/date/date.component.html
@@ -13,5 +13,5 @@
   class="ordinalContent"
   [style.fontSize]="shared.getFontSize(settings.config.date.week.scaling, 6)"
   [style.transform]="shared.getOffset(settings.config.date.week.offset)">
-  <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.dayOfYear.enabled'> / </span><!--day of year--><span *ngIf='settings.config.date.dayOfYear.enabled'>{{settings.config.date.dayOfYear.label}} {{getDayOfYear()}}</span>
+  <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.julianDate.enabled'> / </span><!--day of year--><span *ngIf='settings.config.date.julianDate.enabled'>{{settings.config.date.julianDate.label}} {{getJulianDate()}}</span>
 </div>

--- a/src/app/tab/date/date.component.html
+++ b/src/app/tab/date/date.component.html
@@ -9,9 +9,9 @@
     {{ getWeekday() }}<ng-container *ngSwitchCase="10"><!-- dd/MM/YYYY -->{{ getDay() }}<span *ngIf='settings.config.date.day.enabled && settings.config.date.month.enabled' [ngClass]="{ dim: settings.config.date.dimDelimiter }">{{ getDelimiter() }}</span>{{ getMonth() }}<span *ngIf='(settings.config.date.month.enabled && settings.config.date.year.enabled) || (settings.config.date.day.enabled && settings.config.date.year.enabled)' [ngClass]="{ dim: settings.config.date.dimDelimiter }">{{ getDelimiter() }}</span>{{ getYear() }}</ng-container><ng-container *ngSwitchCase="20"><!-- MM/dd/YYYY -->{{ getMonth() }}<span *ngIf='settings.config.date.month.enabled && settings.config.date.day.enabled' [ngClass]="{ dim: settings.config.date.dimDelimiter }">{{ getDelimiter() }}</span>{{ getDay() }}<span *ngIf='(settings.config.date.day.enabled && settings.config.date.year.enabled) || (settings.config.date.month.enabled && settings.config.date.year.enabled)' [ngClass]="{ dim: settings.config.date.dimDelimiter }">{{ getDelimiter() }}</span>{{ getYear() }}</ng-container><ng-container *ngSwitchCase="30"><!-- YYYY/MM/dd -->{{ getYear() }}<span *ngIf='settings.config.date.year.enabled && settings.config.date.month.enabled' [ngClass]="{ dim: settings.config.date.dimDelimiter }">{{ getDelimiter() }}</span>{{ getMonth() }}<span *ngIf='(settings.config.date.month.enabled && settings.config.date.day.enabled) || (settings.config.date.year.enabled && settings.config.date.day.enabled)' [ngClass]="{ dim: settings.config.date.dimDelimiter }">{{ getDelimiter() }}</span>{{ getDay() }}</ng-container>
   </ng-container>
 </div>
-<div class="weekLabel"
-  *ngIf="settings.config.date.week.enabled"
+<div
+  class="ordinalContent"
   [style.fontSize]="shared.getFontSize(settings.config.date.week.scaling, 6)"
   [style.transform]="shared.getOffset(settings.config.date.week.offset)">
-  {{settings.config.date.week.label}} {{getWeekNumber()}}
+  <!--week number--><span class="weekLabel" *ngIf="settings.config.date.week.enabled">{{settings.config.date.week.label}} {{getWeekNumber()}}</span><!--delimiter--><span *ngIf='settings.config.date.week.enabled && settings.config.date.dayOfYear.enabled'> / </span><!--day of year--><span *ngIf='settings.config.date.dayOfYear.enabled'>{{settings.config.date.dayOfYear.label}} {{getDayOfYear()}}</span>
 </div>

--- a/src/app/tab/date/date.component.ts
+++ b/src/app/tab/date/date.component.ts
@@ -193,6 +193,10 @@ export class TabDateComponent implements OnInit {
     return this.settings.config.date.short.delimiter;
   }
 
+  getOrdinalContentDelimiter() {
+    return this.settings.config.date.ordinalContent.delimiter;
+  }
+
   getWeekday(): string {
     moment.locale(this.settings.config.i18n.lang);
     let current = this.currentDate;

--- a/src/app/tab/date/date.component.ts
+++ b/src/app/tab/date/date.component.ts
@@ -224,6 +224,28 @@ export class TabDateComponent implements OnInit {
     return '';
   }
 
+  getDayOfYear(): string {
+    moment.locale(this.settings.config.i18n.lang);
+    let current = this.currentDate;
+    let c = this.settings.config.date;
+    let zone = this.getZone(c.timezone);
+    let date = moment(current).tz(zone);
+
+    let newYear = new Date(current.getFullYear(), 0, 1, 0, 0, 0); // month is 0 indexed
+    let difference = current.getTime() - newYear.getTime();
+    let dayOfYear = difference/1000/60/60/24;
+    return '' + (Math.trunc(dayOfYear) + 1);
+
+
+    // let day = c.day.twoDigit ? date.format('DD') : date.format('D');
+    // if (c.short.enabled) {
+    //   if (c.day.enabled) {
+    //     return day;
+    //   }
+    // }
+    // return '';
+  }
+
   getMonth(): string {
     moment.locale(this.settings.config.i18n.lang);
     let current = this.currentDate;

--- a/src/app/tab/date/date.component.ts
+++ b/src/app/tab/date/date.component.ts
@@ -224,7 +224,7 @@ export class TabDateComponent implements OnInit {
     return '';
   }
 
-  getDayOfYear(): string {
+  getJulianDate(): string {
     moment.locale(this.settings.config.i18n.lang);
     let current = this.currentDate;
     let c = this.settings.config.date;
@@ -233,17 +233,8 @@ export class TabDateComponent implements OnInit {
 
     let newYear = new Date(current.getFullYear(), 0, 1, 0, 0, 0); // month is 0 indexed
     let difference = current.getTime() - newYear.getTime();
-    let dayOfYear = difference/1000/60/60/24;
-    return '' + (Math.trunc(dayOfYear) + 1);
-
-
-    // let day = c.day.twoDigit ? date.format('DD') : date.format('D');
-    // if (c.short.enabled) {
-    //   if (c.day.enabled) {
-    //     return day;
-    //   }
-    // }
-    // return '';
+    let julianDate = difference/1000/60/60/24;
+    return '' + (Math.trunc(julianDate) + 1);
   }
 
   getMonth(): string {

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -129,12 +129,15 @@
       "enableWeekNum": "Enable week number",
       "enableJulianDate": "Enable day of year",
       "enableYear": "Enable year",
+      "julianDateLabel": "Julian date label",
       "month": "Month",
+      "ordinalContent": "Ordinal content",
       "shortDate": "Short date",
       "twoDigit": "Two-digit",
       "weekIso": "ISO week number",
       "weekIsoDesc": "Use the ISO week date system from ISO 8601 date and time standard.",
       "weekNum": "Week number",
+      "weekNumLabel": "Week # label",
       "year": "Year"
     },
     "design": {

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -127,7 +127,7 @@
       "enableMonth": "Enable month",
       "enableShortDate": "Enable short date",
       "enableWeekNum": "Enable week number",
-      "enableDayOfYear": "Enable day of year",
+      "enableJulianDate": "Enable day of year",
       "enableYear": "Enable year",
       "month": "Month",
       "shortDate": "Short date",

--- a/src/assets/i18n/en-US.json
+++ b/src/assets/i18n/en-US.json
@@ -127,6 +127,7 @@
       "enableMonth": "Enable month",
       "enableShortDate": "Enable short date",
       "enableWeekNum": "Enable week number",
+      "enableDayOfYear": "Enable day of year",
       "enableYear": "Enable year",
       "month": "Month",
       "shortDate": "Short date",


### PR DESCRIPTION
## What?
Julian date is calculating the current date as the nth date of the year, out of 365 (or 366). For example, November 29th on a non-leap year is Day 333. 

This pull request's changes include:

1. Calculating today's Julian date
2. Toggle button to display Julian date
3. Custom delimiter between week number & Julian date, should both be displayed
4. Reorganizing week number & Julian date to be under the umbrella of "ordinal content"

Fixes #237

This PR additionally includes the pull request template that's used when writing this PR. Feel free to delete it!

## Why?
This is a requested enhancement feature and a currently open issue: [https://github.com/bluecaret/carettab/issues/237](https://github.com/bluecaret/carettab/issues/237). The reorganization should allow more extensibility of the 2nd row of date content (ie "ordinal content"), instead of being limited to just holding the week number. 

## How?
- RE: calculating Julian date. For cleaner code, I opted to calculate it by `current.getTime() - newYear.getTime()`, which is the amount of miliseconds between this year's new year till now. And then divide by 1000 (miliseconds per second) / 60 (seconds per min) / 60 (min per hour) / 24 (hour per day). This calculation will be flexible to the different number of days in a month as well as leap years. 
- RE: reorganizing into "ordinal content". Previously, the 2nd row of date was purely "week number", and it had its own font size and offsets. In this PR, I created a new term "ordinal content" that encapsulates the 2nd row of date to controls the font size & offset for both week number and Julian date. Though, week number specific settings will only appear when week number is enabled, and vice versa. This should allow the 2nd row to be more extensible. 

## Testing?
- Successful local dev build
- Manual testing through clicking and refreshing

## Screenshots
Screenshot of the settings regarding Julian date option in "date" panel + Julian date appearing next to week number:
![](https://files.slack.com/files-pri/T02E7E44761-F02P03VHP5J/juliandate.png?pub_secret=7f26094edb)

## Anything Else?
- There may be a better word choice than "ordinal content"
- Translation is needed for the numerous blurbs that appears in the "date" panel:
    - enableJulianDate
    - julianDateLabel
    - ordinalContent
    - weekNumLabel

<!-- Read more about pull requests: https://www.pullrequest.com/blog/writing-a-great-pull-request-description/  -->