### PR TITLE
remove  a  : in url  in many  translation files

### DIFF
--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Melden Sie sich für Premium an, um auf diese Funktion zuzugreifen",
     "style": "Stil",
     "subscribeNow": "Jetzt abonnieren",
-    "subscriptionBilledOn": "Das Abonnement wird monatlich wiederkehrend abgerechnet. Jederzeit aus beliebigem Grund kündbar. <br />Zahlungen werden über Stripe durch ExtensionPay abgewickelt. Lesen Sie die <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">Datenschutzbestimmungen</a>.",
+    "subscriptionBilledOn": "Das Abonnement wird monatlich wiederkehrend abgerechnet. Jederzeit aus beliebigem Grund kündbar. <br />Zahlungen werden über Stripe durch ExtensionPay abgewickelt. Lesen Sie die <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">Datenschutzbestimmungen</a>.",
     "supportTheDevelopmentOfCarettab": "Unterstützen Sie die Entwicklung von CaretTab mit einem Premium-Abonnement. Hier ist, was Sie bekommen:",
     "tabTitle": "Registerkarte Titel",
     "tabTitleCustomText": "Benutzerdefinierter Text",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Regístrate en Premium para acceder a esta función",
     "style": "Estilo",
     "subscribeNow": "Suscríbase ahora",
-    "subscriptionBilledOn": "Suscripción facturada mensualmente de forma recurrente. Cancelar en cualquier momento por cualquier motivo. <br />Pagos procesados vía Stripe a través de ExtensionPay. Ver la <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">política de privacidad</a>.",
+    "subscriptionBilledOn": "Suscripción facturada mensualmente de forma recurrente. Cancelar en cualquier momento por cualquier motivo. <br />Pagos procesados vía Stripe a través de ExtensionPay. Ver la <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">política de privacidad</a>.",
     "supportTheDevelopmentOfCarettab": "Apoya el desarrollo de CaretTab con una suscripción Premium. Esto es lo que obtienes:",
     "tabTitle": "Título de la pestaña",
     "tabTitleCustomText": "Texto personalizado",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "S'inscrire à Premium pour accéder à cette fonctionnalité",
     "style": "Style",
     "subscribeNow": "S'abonner",
-    "subscriptionBilledOn": "L'abonnement est facturé sur une base mensuelle récurrente. Annulation à tout moment pour n'importe quelle raison. <Les paiements sont traités par Stripe via ExtensionPay. Consultez la <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">politique de confidentialité</a>.",
+    "subscriptionBilledOn": "L'abonnement est facturé sur une base mensuelle récurrente. Annulation à tout moment pour n'importe quelle raison. <Les paiements sont traités par Stripe via ExtensionPay. Consultez la <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">politique de confidentialité</a>.",
     "supportTheDevelopmentOfCarettab": "Soutenez le développement de CaretTab avec un abonnement Premium. Voici ce que vous obtenez :",
     "tabTitle": "Titre de l'onglet",
     "tabTitleCustomText": "Texte personnalisé",

--- a/src/locales/he.json
+++ b/src/locales/he.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "הירשם ל-Premium כדי לגשת לתכונה זו",
     "style": "סִגְנוֹן",
     "subscribeNow": "הירשם עכשיו",
-    "subscriptionBilledOn": "מנוי מחויב על בסיס חודשי חוזר. \nבטל בכל עת מכל סיבה שהיא. \n<br />תשלומים מעובדים באמצעות Stripe דרך ExtensionPay. \nעיין ב<a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">מדיניות הפרטיות</a>.",
+    "subscriptionBilledOn": "מנוי מחויב על בסיס חודשי חוזר. \nבטל בכל עת מכל סיבה שהיא. \n<br />תשלומים מעובדים באמצעות Stripe דרך ExtensionPay. \nעיין ב<a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">מדיניות הפרטיות</a>.",
     "supportTheDevelopmentOfCarettab": "תמכו בפיתוח CaretTab עם מנוי פרימיום. \nהנה מה שאתה מקבל:",
     "tabTitle": "כותרת הטבלה",
     "tabTitleCustomText": "טקסט מותאם אישית",

--- a/src/locales/it.json
+++ b/src/locales/it.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Iscriviti a Premium per accedere a questa funzione",
     "style": "Stile",
     "subscribeNow": "Iscriviti ora",
-    "subscriptionBilledOn": "L'abbonamento viene fatturato su base mensile ricorrente. È possibile annullare l'abbonamento in qualsiasi momento e per qualsiasi motivo. <br />Pagamenti elaborati tramite Stripe attraverso ExtensionPay. Visualizza la <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">politica sulla privacy</a>.",
+    "subscriptionBilledOn": "L'abbonamento viene fatturato su base mensile ricorrente. È possibile annullare l'abbonamento in qualsiasi momento e per qualsiasi motivo. <br />Pagamenti elaborati tramite Stripe attraverso ExtensionPay. Visualizza la <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">politica sulla privacy</a>.",
     "supportTheDevelopmentOfCarettab": "Sostenete lo sviluppo di CaretTab con un abbonamento Premium. Ecco cosa otterrete:",
     "tabTitle": "Titolo della scheda",
     "tabTitleCustomText": "Testo personalizzato",

--- a/src/locales/ja.json
+++ b/src/locales/ja.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "この機能を利用するにはプレミアムに登録する",
     "style": "スタイル",
     "subscribeNow": "今すぐ申し込む",
-    "subscriptionBilledOn": "サブスクリプションは毎月定期的に課金されます。理由の如何を問わず、いつでもキャンセル可能。<br />お支払いはExtensionPayを通じてStripeで処理されます。<a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">プライバシーポリシー</a>をご覧ください。",
+    "subscriptionBilledOn": "サブスクリプションは毎月定期的に課金されます。理由の如何を問わず、いつでもキャンセル可能。<br />お支払いはExtensionPayを通じてStripeで処理されます。<a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">プライバシーポリシー</a>をご覧ください。",
     "supportTheDevelopmentOfCarettab": "プレミアムサブスクリプションでCaretTabの開発をサポートしましょう。以下の特典があります：",
     "tabTitle": "タブタイトル",
     "tabTitleCustomText": "カスタムテキスト",

--- a/src/locales/ko.json
+++ b/src/locales/ko.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "이 기능에 액세스하려면 프리미엄에 가입하세요.",
     "style": "스타일",
     "subscribeNow": "지금 구독하기",
-    "subscriptionBilledOn": "매월 정기적으로 청구되는 구독입니다. 어떤 이유로든 언제든지 취소할 수 있습니다. <br />결제는 Stripe를 통해 익스텐션페이를 통해 처리됩니다. <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">개인정보처리방침</a>을 확인하세요.",
+    "subscriptionBilledOn": "매월 정기적으로 청구되는 구독입니다. 어떤 이유로든 언제든지 취소할 수 있습니다. <br />결제는 Stripe를 통해 익스텐션페이를 통해 처리됩니다. <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">개인정보처리방침</a>을 확인하세요.",
     "supportTheDevelopmentOfCarettab": "프리미엄 구독으로 케어탭의 개발을 지원하세요. 제공되는 혜택은 다음과 같습니다:",
     "tabTitle": "탭 제목",
     "tabTitleCustomText": "사용자 지정 텍스트",

--- a/src/locales/pt.json
+++ b/src/locales/pt.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Inscreva-se no Premium para aceder a esta funcionalidade",
     "style": "Estilo",
     "subscribeNow": "Subscrever agora",
-    "subscriptionBilledOn": "A subscrição é facturada numa base mensal recorrente. Cancelamento a qualquer momento por qualquer motivo. <br />Pagamentos processados via Stripe através do ExtensionPay. Ver a <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">política de privacidade</a>.",
+    "subscriptionBilledOn": "A subscrição é facturada numa base mensal recorrente. Cancelamento a qualquer momento por qualquer motivo. <br />Pagamentos processados via Stripe através do ExtensionPay. Ver a <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">política de privacidade</a>.",
     "supportTheDevelopmentOfCarettab": "Apoie o desenvolvimento do CaretTab com uma subscrição Premium. Eis o que obtém:",
     "tabTitle": "Título do separador",
     "tabTitleCustomText": "Texto personalizado",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Подпишитесь на Premium, чтобы получить доступ к этой функции",
     "style": "Стиль",
     "subscribeNow": "Подписаться сейчас",
-    "subscriptionBilledOn": "Счет за подписку выставляется ежемесячно на рекуррентной основе. Отмена в любое время по любой причине. <br /> Платежи осуществляются через Stripe посредством ExtensionPay. Ознакомьтесь с <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">политикой конфиденциальности</a>.",
+    "subscriptionBilledOn": "Счет за подписку выставляется ежемесячно на рекуррентной основе. Отмена в любое время по любой причине. <br /> Платежи осуществляются через Stripe посредством ExtensionPay. Ознакомьтесь с <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">политикой конфиденциальности</a>.",
     "supportTheDevelopmentOfCarettab": "Поддержите развитие CaretTab с помощью подписки Premium. Вот что вы получите:",
     "tabTitle": "Вкладка Название",
     "tabTitleCustomText": "Пользовательский текст",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Registrera dig för Premium för att få tillgång till denna funktion",
     "style": "Stil",
     "subscribeNow": "Prenumerera nu",
-    "subscriptionBilledOn": "Abonnemanget faktureras månadsvis återkommande. Kan sägas upp när som helst av vilken anledning som helst. <br /> Betalningar behandlas via Stripe genom ExtensionPay. Visa <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">sekretesspolicyn</a>.",
+    "subscriptionBilledOn": "Abonnemanget faktureras månadsvis återkommande. Kan sägas upp när som helst av vilken anledning som helst. <br /> Betalningar behandlas via Stripe genom ExtensionPay. Visa <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">sekretesspolicyn</a>.",
     "supportTheDevelopmentOfCarettab": "Stöd utvecklingen av CaretTab med en Premium-prenumeration. Här är vad du får:",
     "tabTitle": "Flik Titel",
     "tabTitleCustomText": "Anpassad text",

--- a/src/locales/uk.json
+++ b/src/locales/uk.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Підпишіться на Premium, щоб отримати доступ до цієї функції",
     "style": "Стиль",
     "subscribeNow": "Підпишіться зараз",
-    "subscriptionBilledOn": "Підписка оплачується на щомісячній основі. Скасувати в будь-який час з будь-якої причини. <br />Платежі обробляються через Stripe через ExtensionPay. Перегляньте <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">політику конфіденційності</a>.",
+    "subscriptionBilledOn": "Підписка оплачується на щомісячній основі. Скасувати в будь-який час з будь-якої причини. <br />Платежі обробляються через Stripe через ExtensionPay. Перегляньте <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">політику конфіденційності</a>.",
     "supportTheDevelopmentOfCarettab": "Підтримайте розвиток CaretTab з підпискою Premium. Ось що ви отримаєте:",
     "tabTitle": "Назва вкладки",
     "tabTitleCustomText": "Користувацький текст",

--- a/src/locales/ur.json
+++ b/src/locales/ur.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "اس خصوصیت تک رسائی کے لیے پریمیم کے لیے سائن اپ کریں۔",
     "style": "انداز",
     "subscribeNow": "اب سبسکرائب کریں",
-    "subscriptionBilledOn": "سبسکرپشن کا بل ماہانہ اعادی بنیاد پر لگایا جاتا ہے۔ \nکسی بھی وجہ سے کسی بھی وقت منسوخ کریں۔ \n<br />ExtensionPay کے ذریعے سٹرائپ کے ذریعے ادائیگیوں پر کارروائی کی جاتی ہے۔ \n<a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">رازداری کی پالیسی</a> دیکھیں۔",
+    "subscriptionBilledOn": "سبسکرپشن کا بل ماہانہ اعادی بنیاد پر لگایا جاتا ہے۔ \nکسی بھی وجہ سے کسی بھی وقت منسوخ کریں۔ \n<br />ExtensionPay کے ذریعے سٹرائپ کے ذریعے ادائیگیوں پر کارروائی کی جاتی ہے۔ \n<a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">رازداری کی پالیسی</a> دیکھیں۔",
     "supportTheDevelopmentOfCarettab": "پریمیم سبسکرپشن کے ساتھ کیریٹ ٹیب کی ترقی میں تعاون کریں۔ \nآپ کو جو ملتا ہے وہ یہ ہے:",
     "tabTitle": "ٹیب کا عنوان",
     "tabTitleCustomText": "حسب ضرورت متن",

--- a/src/locales/vi.json
+++ b/src/locales/vi.json
@@ -166,7 +166,7 @@
     "signUpForPremiumToAccessThisFeature": "Đăng ký Premium để truy cập tính năng này",
     "style": "Phong cách",
     "subscribeNow": "Theo dõi ngay",
-    "subscriptionBilledOn": "Đăng ký được lập hóa đơn trên cơ sở định kỳ hàng tháng. \nHủy bỏ bất cứ lúc nào vì bất kỳ lý do gì. \n<br />Các khoản thanh toán được xử lý qua Stripe thông qua ExtensionPay. \nXem <a :href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">chính sách quyền riêng tư</a>.",
+    "subscriptionBilledOn": "Đăng ký được lập hóa đơn trên cơ sở định kỳ hàng tháng. \nHủy bỏ bất cứ lúc nào vì bất kỳ lý do gì. \n<br />Các khoản thanh toán được xử lý qua Stripe thông qua ExtensionPay. \nXem <a href=\"https://www.bluecaret.com/privacy/\" rel=\"noreferrer\" target=\"_blank\">chính sách quyền riêng tư</a>.",
     "supportTheDevelopmentOfCarettab": "Hỗ trợ sự phát triển của CaretTab với đăng ký Premium. \nĐây là những gì bạn nhận được:",
     "tabTitle": "Tiêu đề tab",
     "tabTitleCustomText": "Văn bản tùy chỉnh",


### PR DESCRIPTION
- url Fixes in translation

## Describe your fix

a ":" was in the links before the  href in all translations file except en and  zh.

Note the strange thing is that "this "url" is not present in the  en version.

So perhaps the good correction is to remove the link  in all translation or add it in en and zh.

I wait a request of @bluecaret  to do more change about that.

 

